### PR TITLE
Fix zluda-python.py not starting

### DIFF
--- a/cli/zluda-python.py
+++ b/cli/zluda-python.py
@@ -27,6 +27,7 @@ if __name__ == '__main__':
     sys.path.append(os.getcwd())
 
     from modules import zluda_installer
+    zluda_installer.load_core_modules()
     zluda_installer.install()
     zluda_installer.make_copy()
     zluda_installer.load()


### PR DESCRIPTION
## Description

`zluda-python.py` is currently not working as `core` is `None` when `zluda_installer.load()` is called before `zluda_installer.load_core_modules()`

Calling `zluda_installer.load_core_modules()` before `zluda_installer.load()` fixes the issue

## Notes

In respect to these changes the `load_core_modules()` can be removed from the  `zluda_installer.load()` function or moved to the top of the function inside a `if core is None`? @lshqqytiger

## Environment and Testing

Now works again, Windows 11, Python 3.11.9, ZLUDA 3.9.2
