### PR TITLE
Dehardcoding latent_channels in full_vae_decode

### DIFF
--- a/modules/processing_vae.py
+++ b/modules/processing_vae.py
@@ -135,10 +135,11 @@ def full_vae_decode(latents, model):
     latents_mean = model.vae.config.get("latents_mean", None)
     latents_std = model.vae.config.get("latents_std", None)
     scaling_factor = model.vae.config.get("scaling_factor", None)
+    latent_channels = model.vae.config.get("latent_channels", 4)
     shift_factor = model.vae.config.get("shift_factor", None)
     if latents_mean and latents_std:
-        latents_mean = (torch.tensor(latents_mean).view(1, 4, 1, 1).to(latents.device, latents.dtype))
-        latents_std = (torch.tensor(latents_std).view(1, 4, 1, 1).to(latents.device, latents.dtype))
+        latents_mean = (torch.tensor(latents_mean).view(1, latent_channels, 1, 1).to(latents.device, latents.dtype))
+        latents_std = (torch.tensor(latents_std).view(1, latent_channels, 1, 1).to(latents.device, latents.dtype))
         latents = ((latents * latents_std) / scaling_factor) + latents_mean
     else:
         latents = latents / scaling_factor


### PR DESCRIPTION
## Description

Dehardcoding latent_channels in full_vae_decode

## Notes

I tested it only with SD 1.5 with 16channel VAE, but it should work with every custom model that have latent channels defined in config.