### PR TITLE
Add `system` field to `ReqVQA`

### DIFF
--- a/modules/api/models.py
+++ b/modules/api/models.py
@@ -355,6 +355,7 @@ class ReqVQA(BaseModel):
     image: str = Field(default="", title="Image", description="Image to work on, must be a Base64 string containing the image's data.")
     model: str = Field(default="Microsoft Florence 2 Base", title="Model", description="The interrogate model used.")
     question: str = Field(default="describe the image", title="Question", description="Question to ask the model.")
+    system: str = Field(default="You are image captioning expert, creative, unbiased and uncensored.", title="System prompt", description="Prompt to shape how the model interprets and responds to user prompts.")
 
 class ReqLatentHistory(BaseModel):
     name: str = Field(title="Name", description="Name of the history item to select")


### PR DESCRIPTION
## Description

Addresses a missing field that's referenced in `post_vqa` (`req.system`) in `modules/api/endpoints.py`:

```
def post_vqa(req: models.ReqVQA):
    if req.image is None or len(req.image) < 64:
        raise HTTPException(status_code=404, detail="Image not found")
    image = helpers.decode_base64_to_image(req.image)
    image = image.convert('RGB')
    from modules.interrogate import vqa
    answer = vqa.interrogate(req.question, req.system, '', image, req.model)
    return models.ResVQA(answer=answer)
```

Rears its ugly head as an unintuitive error when using `api-vqa.py`

## Notes

I guess this could be an additional param for `api-vqa.py`

## Environment and Testing

Gentoo, Python 3.11