### PR TITLE
ci: update Dockerfile

### DIFF
--- a/configs/Dockerfile.cuda
+++ b/configs/Dockerfile.cuda
@@ -17,8 +17,10 @@ LABEL org.opencontainers.image.base.name="https://hub.docker.com/pytorch/pytorch
 LABEL org.opencontainers.image.version="latest"
 
 # minimum install
-RUN ["apt-get", "-y", "update"]
-RUN ["apt-get", "-y", "install", "git", "build-essential", "google-perftools", "curl", "ffmpeg"]
+RUN apt-get -y update && \
+    apt-get -y install git build-essential google-perftools curl ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
 # optional if full cuda-dev is required by some downstream library
 # RUN ["apt-get", "-y", "nvidia-cuda-toolkit"]
 RUN ["/usr/sbin/ldconfig"]


### PR DESCRIPTION
## Description

This updating the Dockerfile.cuda to follow [best practices](https://docs.docker.com/build/building/best-practices/#apt-get) when using apt-get. Seems like the other Dockerfiles already follow them

## Notes

The `rm -rf /var/lib/apt/lists/*` may not be needed, but it's difficult to tell exactly what ubuntu image pytorch is using and shouldn't hurt.

## Environment and Testing

The image still builds and runs, should basically just change image layer size.
