### PR TITLE
When using the openvino backend, do not look for an nvidia gpu.

### DIFF
--- a/modules/devices.py
+++ b/modules/devices.py
@@ -183,6 +183,8 @@ def get_cuda_device_string():
 
 
 def get_optimal_device_name():
+    if backend == 'openvino':
+        return "cpu"
     if cuda_ok or backend == 'directml':
         return get_cuda_device_string()
     if has_mps() and backend != 'openvino':


### PR DESCRIPTION
## Description

This fixes the situation where the openvino backend is asked for using the --use-openvino flag, but an nvidia gpu is still detected and used.  Issue reference: https://github.com/vladmandic/sdnext/issues/3920

## Notes

This fix does not break Intel ARC A series gpus using the Opvenvino backend.  This is in spite of the `device` variable being set to `cpu`.

## Environment and Testing

I have tested this on two Fedora 41 systems running Stable Diffusion 3.5 Medium due to memory constraints on the latter system.

**XEON 8468 + Nvidia RTX 4000 Ada**:  The Openvino backend properly uses cpu only, whereas before it tried to swap to the Nvidia backend and use the Nvidia gpu.

**Ryzen 5600X + Intel Arc A380**:  The Openvino backend picked up the fact that the A380 was available as an Openvino device (note the device variable quirk above).  Log messages show:

    Torch parameters: backend=openvino device=GPU config=Auto dtype=torch.float32 context=no_grad nohalf=True nohalfvae=True upcast=False deterministic=False tunable=[False, False] fp16=fail bf16=fail optimization="Scaled-Dot-Product"
 
