### PR TITLE
Fix lycoris wrong errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log for SD.Next
 
-## Update for 2025-06-05
+## Update for 2025-06-06
+
+- **Torch**:
+    - set default to `torch==2.7.1`  
 
 - **SDNQ Quantization**  
     - Add group size support for convolutional layers  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - **Fixes**
   - Meissonic with multiple generators  
+  - Kandinsky V2.2 invalid attention processor  
 
 ## Update for 2025-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **SDNQ Quantization**  
     - Add group size support for convolutional layers  
     - Add quantized matmul support for for convolutional layers  
+    - Fix forced FP32 with tensorwise FP8 matmul  
+    - Fix PyTorch <= 2.4 compatibility with FP8 matmul  
     - Fix VAE with conv quant  
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ## Update for 2025-06-06
 
-- **Torch**:
-    - set default to `torch==2.7.1`  
+- **Changes**  
+  - Increase the medvram mode threshold from 8GB to 12GB  
+  - Set CPU backend to use FP32 by default  
+
+- **Torch**  
+  - set default to `torch==2.7.1`  
 
 - **SDNQ Quantization**  
-    - Add group size support for convolutional layers  
-    - Add quantized matmul support for for convolutional layers  
-    - Fix forced FP32 with tensorwise FP8 matmul  
-    - Fix PyTorch <= 2.4 compatibility with FP8 matmul  
-    - Fix VAE with conv quant  
+  - Add group size support for convolutional layers  
+  - Add quantized matmul support for for convolutional layers  
+  - Fix forced FP32 with tensorwise FP8 matmul  
+  - Fix PyTorch <= 2.4 compatibility with FP8 matmul  
+  - Fix VAE with conv quant  
 
 
 ## Update for 2025-06-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   - Fix PyTorch <= 2.4 compatibility with FP8 matmul  
   - Fix VAE with conv quant  
 
+- **Fixes**
+  - Meissonic with multiple generators  
 
 ## Update for 2025-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log for SD.Next
 
+## Update for 2025-06-05
+
+- **SDNQ Quantization**  
+    - Add group size support for convolutional layers  
+    - Add quantized matmul support for for convolutional layers  
+    - Fix VAE with conv quant  
+
+
 ## Update for 2025-06-02
 
 ### Highlights for 2025-06-02
@@ -31,7 +39,6 @@ Take a look at [Docs](https://github.com/vladmandic/sdnext/wiki/Docs), [Hints](h
     - `INT4` -> `uint4`  
   - Add `float8_e4m3fn`, `float8_e5m2`, `float8_e4m3fnuz`, `float8_e5m2fnuz`, `int6`, `uint6`, `int2`, `uint2` and `uint1` support  
   - Add quantized matmul support for `float8_e4m3fn` and `float8_e5m2`  
-  - Add group size support for convolutional layers  
   - Set the default quant mode to `pre`  
   - Use per token input quant with int8 and fp8 quantized matmul  
   - Implement better layer hijacks  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Meissonic with multiple generators  
   - Kandinsky V2.2 invalid attention processor  
   - PixArt Sigma Small and Large loading  
+  - TAESD previews with PixArt  
 
 ## Update for 2025-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **Fixes**
   - Meissonic with multiple generators  
   - Kandinsky V2.2 invalid attention processor  
+  - PixArt Sigma Small and Large loading  
 
 ## Update for 2025-06-02
 

--- a/installer.py
+++ b/installer.py
@@ -582,7 +582,7 @@ def install_cuda():
         cmd = os.environ.get('TORCH_COMMAND', '--upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128 --extra-index-url https://download.pytorch.org/whl/nightly/cu126')
     else:
         # cmd = os.environ.get('TORCH_COMMAND', 'torch==2.6.0+cu126 torchvision==0.21.0+cu126 --index-url https://download.pytorch.org/whl/cu126')
-        cmd = os.environ.get('TORCH_COMMAND', 'torch==2.7.0+cu128 torchvision==0.22.0+cu128 --index-url https://download.pytorch.org/whl/cu128')
+        cmd = os.environ.get('TORCH_COMMAND', 'torch==2.7.1+cu128 torchvision==0.22.1+cu128 --index-url https://download.pytorch.org/whl/cu128')
     return cmd
 
 
@@ -655,7 +655,7 @@ def install_rocm_zluda():
         if error is None:
             try:
                 zluda_installer.load()
-                torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.0 torchvision --index-url https://download.pytorch.org/whl/cu118')
+                torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.1 torchvision --index-url https://download.pytorch.org/whl/cu118')
             except Exception as e:
                 error = e
                 log.warning(f'Failed to load ZLUDA: {e}')
@@ -675,10 +675,10 @@ def install_rocm_zluda():
                 torch_command = os.environ.get('TORCH_COMMAND', '--upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm6.2.4')
         else:
             if rocm.version is None or float(rocm.version) >= 6.3: # assume the latest if version check fails
-                torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.0+rocm6.3 torchvision==0.22.0+rocm6.3 --index-url https://download.pytorch.org/whl/rocm6.3')
+                torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.1+rocm6.3 torchvision==0.22.1+rocm6.3 --index-url https://download.pytorch.org/whl/rocm6.3')
             elif rocm.version == "6.2":
-                # use rocm 6.2.4 instead of 6.2 as torch==2.7.0+rocm6.2 doesn't exists
-                torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.0+rocm6.2.4 torchvision==0.22.0+rocm6.2.4 --index-url https://download.pytorch.org/whl/rocm6.2.4')
+                # use rocm 6.2.4 instead of 6.2 as torch==2.7.1+rocm6.2 doesn't exists
+                torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.1+rocm6.2.4 torchvision==0.22.1+rocm6.2.4 --index-url https://download.pytorch.org/whl/rocm6.2.4')
             elif rocm.version == "6.1":
                 torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.6.0+rocm6.1 torchvision==0.21.0+rocm6.1 --index-url https://download.pytorch.org/whl/rocm6.1')
             elif rocm.version == "6.0":
@@ -736,7 +736,7 @@ def install_ipex(torch_command):
     if args.use_nightly:
         torch_command = os.environ.get('TORCH_COMMAND', '--upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/xpu')
     else:
-        torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.0+xpu torchvision==0.22.0+xpu --index-url https://download.pytorch.org/whl/xpu')
+        torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.1+xpu torchvision==0.22.1+xpu --index-url https://download.pytorch.org/whl/xpu')
 
     ts('ipex', t_start)
     return torch_command
@@ -747,9 +747,9 @@ def install_openvino(torch_command):
     check_python(supported_minors=[9, 10, 11, 12], reason='OpenVINO backend requires a Python version between 3.9 and 3.12')
     log.info('OpenVINO: selected')
     if sys.platform == 'darwin':
-        torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.0 torchvision==0.22.0')
+        torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.1 torchvision==0.22.1')
     else:
-        torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.0+cpu torchvision==0.22.0+cpu --index-url https://download.pytorch.org/whl/cpu')
+        torch_command = os.environ.get('TORCH_COMMAND', 'torch==2.7.1+cpu torchvision==0.22.1+cpu --index-url https://download.pytorch.org/whl/cpu')
 
     install(os.environ.get('OPENVINO_COMMAND', 'openvino==2025.1.0'), 'openvino')
     install(os.environ.get('NNCF_COMMAND', 'nncf==2.16.0'), 'nncf')

--- a/modules/devices.py
+++ b/modules/devices.py
@@ -331,7 +331,7 @@ def test_fp16():
     if fp16_ok is not None:
         return fp16_ok
     if opts.cuda_dtype != 'FP16': # don't override if the user sets it
-        if sys.platform == "darwin" or backend == 'openvino': # override
+        if sys.platform == "darwin" or backend in {'openvino', 'cpu'}: # override
             fp16_ok = False
             return fp16_ok
         elif backend == 'rocm':
@@ -362,7 +362,7 @@ def test_bf16():
     if bf16_ok is not None:
         return bf16_ok
     if opts.cuda_dtype != 'BF16': # don't override if the user sets it
-        if sys.platform == "darwin" or backend == 'openvino' or backend == 'directml': # override
+        if sys.platform == "darwin" or backend in {'openvino', 'directml', 'cpu'}: # override
             bf16_ok = False
             return bf16_ok
         elif backend == 'rocm' or backend == 'zluda':

--- a/modules/lora/lora_apply.py
+++ b/modules/lora/lora_apply.py
@@ -147,7 +147,16 @@ def network_add_weights(self: Union[torch.nn.Conv2d, torch.nn.Linear, torch.nn.G
             new_weight = dequant_weight.to(devices.device, dtype=torch.float32) + lora_weights.to(devices.device, dtype=torch.float32)
             self.weight = torch.nn.Parameter(new_weight, requires_grad=False)
             self.sdnq_decompressor = None
-            self = sdnq_quantize_layer(self, sdnq_decompressor.weights_dtype, torch_dtype=devices.dtype, group_size=shared.opts.sdnq_quantize_weights_group_size, quant_conv=shared.opts.sdnq_quantize_conv_layers, use_quantized_matmul=shared.opts.sdnq_use_quantized_matmul, param_name=getattr(self, 'network_layer_name', None))
+            self = sdnq_quantize_layer(
+                self,
+                sdnq_decompressor.weights_dtype,
+                torch_dtype=devices.dtype,
+                group_size=shared.opts.sdnq_quantize_weights_group_size,
+                quant_conv=shared.opts.sdnq_quantize_conv_layers,
+                use_quantized_matmul=shared.opts.sdnq_use_quantized_matmul,
+                use_quantized_matmul_conv=shared.opts.sdnq_use_quantized_matmul_conv,
+                param_name=getattr(self, 'network_layer_name', None),
+            )
             self = self.to(device)
             weight = None
             del dequant_weight

--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -148,8 +148,9 @@ def load_safetensors(name, network_on_disk) -> Union[network.Network, None]:
             if net_module is not None:
                 network_types.append(nettype.__class__.__name__)
                 break
-            module_errors += 1
         if net_module is None:
+            module_errors += 1
+            
             if l.debug:
                 shared.log.error(f'LoRA unhandled: name={name} key={key} weights={weights.w.keys()}')
         else:

--- a/modules/model_pixart.py
+++ b/modules/model_pixart.py
@@ -1,11 +1,19 @@
 import transformers
 import diffusers
+from huggingface_hub import file_exists
 
 
 def load_pixart(checkpoint_info, diffusers_load_config={}):
     from modules import shared, devices, modelloader, sd_models, model_quant
     modelloader.hf_login()
     repo_id = sd_models.path_to_repo(checkpoint_info.name)
+    repo_id_tenc = repo_id
+    repo_id_pipe = repo_id
+
+    if not file_exists(repo_id_tenc, "text_encoder/config.json"):
+        repo_id_tenc = "PixArt-alpha/PixArt-Sigma-XL-2-1024-MS"
+    if not file_exists(repo_id_pipe, "model_index.json"):
+        repo_id_pipe = "PixArt-alpha/PixArt-Sigma-XL-2-1024-MS"
 
     load_args, quant_args = model_quant.get_dit_args(diffusers_load_config, module='Transformer')
     transformer = diffusers.PixArtTransformer2DModel.from_pretrained(
@@ -17,7 +25,7 @@ def load_pixart(checkpoint_info, diffusers_load_config={}):
     )
     load_args, quant_args = model_quant.get_dit_args(diffusers_load_config, module='TE', device_map=True)
     text_encoder = transformers.T5EncoderModel.from_pretrained(
-        repo_id,
+        repo_id_tenc,
         subfolder="text_encoder",
         cache_dir=shared.opts.hfcache_dir,
         **load_args,
@@ -26,7 +34,7 @@ def load_pixart(checkpoint_info, diffusers_load_config={}):
 
     load_args, _quant_args = model_quant.get_dit_args(diffusers_load_config, allow_quant=False)
     pipe = diffusers.PixArtSigmaPipeline.from_pretrained(
-        'PixArt-alpha/PixArt-Sigma-XL-2-1024-MS',
+        repo_id_pipe,
         cache_dir=shared.opts.diffusers_dir,
         transformer=transformer,
         text_encoder=text_encoder,

--- a/modules/model_quant.py
+++ b/modules/model_quant.py
@@ -118,6 +118,7 @@ def create_sdnq_config(kwargs = None, allow_sdnq: bool = True, module: str = 'Mo
                 group_size=shared.opts.sdnq_quantize_weights_group_size,
                 quant_conv=shared.opts.sdnq_quantize_conv_layers,
                 use_quantized_matmul=shared.opts.sdnq_use_quantized_matmul,
+                use_quantized_matmul_conv=shared.opts.sdnq_use_quantized_matmul_conv,
             )
             log.debug(f'Quantization: module="{module}" type=sdnq dtype={shared.opts.sdnq_quantize_weights_mode}')
             if kwargs is None:
@@ -326,6 +327,7 @@ def sdnq_quantize_model(model, op=None, sd_model=None, do_gc=True):
         group_size=shared.opts.sdnq_quantize_weights_group_size,
         quant_conv=shared.opts.sdnq_quantize_conv_layers,
         use_quantized_matmul=shared.opts.sdnq_use_quantized_matmul,
+        use_quantized_matmul_conv=shared.opts.sdnq_use_quantized_matmul_conv,
         param_name=op,
     )
     model.quantization_method = 'SDNQ'

--- a/modules/model_quant_sdnq.py
+++ b/modules/model_quant_sdnq.py
@@ -29,6 +29,7 @@ dtype_dict = {
     "float8_e5m2fnuz": {"min": -57344, "max": 57344, "num_bits": 8, "target_dtype": CustomDtype.FP8, "torch_dtype": torch.float8_e5m2fnuz, "storage_dtype": torch.float8_e5m2fnuz, "is_unsigned": False, "is_integer": False},
 }
 
+use_tensorwise_fp8_matmul = torch_version < 2.5 or devices.backend in {"cpu", "openvino"} or (devices.backend == "cuda" and sys.platform == "win32" and torch_version <= 2.7 and torch.cuda.get_device_capability(devices.device) == (8,9))
 quantized_matmul_dtypes = ("int8", "int6", "int4", "int2", "float8_e4m3fn", "float8_e5m2")
 if devices.backend in {"cpu", "openvino"}:
     quantized_matmul_dtypes += ("float8_e4m3fnuz", "float8_e5m2fnuz")
@@ -49,7 +50,6 @@ def sdnq_quantize_layer(layer, weights_dtype="int8", torch_dtype=None, group_siz
         is_conv_type = False
         is_conv_transpose_type = False
         is_linear_type = False
-        use_tensorwise_fp8_matmul = False
         result_shape = None
         if torch_dtype is None:
             torch_dtype = devices.dtype
@@ -65,10 +65,9 @@ def sdnq_quantize_layer(layer, weights_dtype="int8", torch_dtype=None, group_siz
             group_channel_size = channel_size // layer.groups
             use_quantized_matmul = False
             if shared.opts.sdnq_use_quantized_matmul_conv:
-                use_quantized_matmul = dtype_dict[weights_dtype]["is_integer"] and weights_dtype in quantized_matmul_dtypes and group_channel_size >= 32 and output_channel_size >= 32
-                #if use_quantized_matmul and not dtype_dict[weights_dtype]["is_integer"]:
-                #    use_quantized_matmul = output_channel_size % 16 == 0 and group_channel_size % 16 == 0
-                #    use_tensorwise_fp8_matmul = torch_version < 2.5 or devices.backend in {"cpu", "openvino"} or (devices.backend == "cuda" and sys.platform == "win32" and torch_version <= 2.7 and torch.cuda.get_device_capability(devices.device) == (8,9))
+                use_quantized_matmul = weights_dtype in quantized_matmul_dtypes and group_channel_size >= 32 and output_channel_size >= 32
+                if use_quantized_matmul and not dtype_dict[weights_dtype]["is_integer"]:
+                    use_quantized_matmul = output_channel_size % 16 == 0 and group_channel_size % 16 == 0
                 if use_quantized_matmul:
                     result_shape = layer.weight.shape
                     layer.weight.data = layer.weight.reshape(output_channel_size, -1)
@@ -89,7 +88,6 @@ def sdnq_quantize_layer(layer, weights_dtype="int8", torch_dtype=None, group_siz
                 use_quantized_matmul = weights_dtype in quantized_matmul_dtypes and channel_size >= 32 and output_channel_size >= 32
                 if use_quantized_matmul and not dtype_dict[weights_dtype]["is_integer"]:
                     use_quantized_matmul = output_channel_size % 16 == 0 and channel_size % 16 == 0
-                    use_tensorwise_fp8_matmul = torch_version < 2.5 or devices.backend in {"cpu", "openvino"} or (devices.backend == "cuda" and sys.platform == "win32" and torch_version <= 2.7 and torch.cuda.get_device_capability(devices.device) == (8,9))
 
         if group_size == 0:
             if is_linear_type:
@@ -203,7 +201,13 @@ def sdnq_quantize_layer(layer, weights_dtype="int8", torch_dtype=None, group_siz
                 layer.forward = quantized_linear_forward
         elif is_conv_type:
             if use_quantized_matmul:
-                layer.forward = quantized_conv2d_forward_int8_matmul
+                if dtype_dict[weights_dtype]["is_integer"]:
+                    layer.forward = quantized_conv2d_forward_int8_matmul
+                else:
+                    if use_tensorwise_fp8_matmul:
+                        layer.forward = quantized_conv2d_forward_fp8_matmul_tensorwise
+                    else:
+                        layer.forward = quantized_conv2d_forward_fp8_matmul
             else:
                 layer.forward = quantized_conv_forward
         elif is_conv_transpose_type:
@@ -466,6 +470,89 @@ def int8_matmul(
     return result
 
 
+def conv2d_fp8_matmul(
+    input: torch.FloatTensor,
+    weight: torch.ByteTensor,
+    bias: torch.FloatTensor,
+    scale: torch.FloatTensor,
+    result_shape: torch.Size,
+    weights_dtype: str,
+    reversed_padding_repeated_twice: List[int],
+    padding_mode: str, groups: int,
+    stride_h: int, stride_w: int,
+    padding_h: int, padding_w: int,
+    dilation_h: int, dilation_w: int,
+) -> torch.FloatTensor:
+    return_dtype = input.dtype
+    mm_output_shape, K_h, K_w = get_conv2d_shapes(input.shape, result_shape, stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w)
+    if padding_mode != "zeros":
+        input = torch.nn.functional.pad(input, reversed_padding_repeated_twice, mode=padding_mode)
+        padding_h = padding_w = 0
+
+    input, input_scale = quantize_fp8_matmul_input(
+        torch.nn.functional.unfold(
+            input, kernel_size=(K_h, K_w), padding=(padding_h, padding_w), stride=(stride_h, stride_w), dilation=(dilation_h, dilation_w)
+        ).transpose(1,2),
+    )
+
+    if groups == 1:
+        result = torch._scaled_mm(input, weight, scale_a=input_scale, scale_b=scale, bias=bias, out_dtype=return_dtype).reshape(mm_output_shape).permute(0,3,1,2)
+    else:
+        scale = scale.reshape(groups, 1, scale.shape[1] // groups)
+        input_scale = input_scale.reshape(groups, input_scale.shape[0] // groups, 1)
+        weight = weight.reshape(weight.shape[0], groups, weight.shape[1] // groups).transpose(0,1)
+        input = input.reshape(input.shape[0], groups, input.shape[1] // groups).transpose(0,1)
+        result = []
+        for i in range(groups):
+            result.append(torch._scaled_mm(input[i], weight[i], scale_a=input_scale[i], scale_b=scale[i], bias=None, out_dtype=return_dtype))
+        result = torch.cat(result, dim=-1).reshape(mm_output_shape)
+        if bias is not None:
+            result.add_(bias)
+        result = result.permute(0,3,1,2)
+    return result
+
+
+def conv2d_fp8_matmul_tensorwise(
+    input: torch.FloatTensor,
+    weight: torch.ByteTensor,
+    bias: torch.FloatTensor,
+    scale: torch.FloatTensor,
+    result_shape: torch.Size,
+    weights_dtype: str,
+    reversed_padding_repeated_twice: List[int],
+    padding_mode: str, groups: int,
+    stride_h: int, stride_w: int,
+    padding_h: int, padding_w: int,
+    dilation_h: int, dilation_w: int,
+) -> torch.FloatTensor:
+    return_dtype = input.dtype
+    mm_output_shape, K_h, K_w = get_conv2d_shapes(input.shape, result_shape, stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w)
+    if padding_mode != "zeros":
+        input = torch.nn.functional.pad(input, reversed_padding_repeated_twice, mode=padding_mode)
+        padding_h = padding_w = 0
+
+    input, scale = quantize_fp8_matmul_input_tensorwise(
+        torch.nn.functional.unfold(
+            input, kernel_size=(K_h, K_w), padding=(padding_h, padding_w), stride=(stride_h, stride_w), dilation=(dilation_h, dilation_w)
+        ).transpose(1,2),
+        scale,
+    )
+
+    dummy_input_scale = torch.ones(1, device=input.device, dtype=torch.float32)
+    if groups == 1:
+        result = decompress_symmetric(torch._scaled_mm(input, weight, scale_a=dummy_input_scale, scale_b=dummy_input_scale, bias=None, out_dtype=scale.dtype), scale, return_dtype, mm_output_shape)
+    else:
+        weight = weight.reshape(weight.shape[0], groups, weight.shape[1] // groups).transpose(0,1)
+        input = input.reshape(input.shape[0], groups, input.shape[1] // groups).transpose(0,1)
+        result = []
+        for i in range(groups):
+            result.append(torch._scaled_mm(input[i], weight[i], scale_a=dummy_input_scale, scale_b=dummy_input_scale, bias=None, out_dtype=scale.dtype))
+        result = decompress_symmetric(torch.cat(result, dim=-1), scale, return_dtype, mm_output_shape)
+    if bias is not None:
+        result.add_(bias)
+    return result.permute(0,3,1,2)
+
+
 def conv2d_int8_matmul(
     input: torch.FloatTensor,
     weight: torch.ByteTensor,
@@ -481,17 +568,12 @@ def conv2d_int8_matmul(
     dilation_h: int, dilation_w: int,
 ) -> torch.FloatTensor:
     return_dtype = input.dtype
-    batch_size, _, H_in, W_in = input.shape
-    C_out, _, K_h, K_w = result_shape
-    W_out = (W_in + 2 * padding_w - dilation_w * (K_w - 1) - 1) // stride_w + 1
-    H_out = (H_in + 2 * padding_h - dilation_h * (K_h - 1) - 1) // stride_h + 1
-    mm_output_shape =  (batch_size, H_out, W_out, C_out)
-
-    if compressed_weight_shape is not None:
-        weight = unpack_int_symetric(weight, compressed_weight_shape, weights_dtype, dtype=torch.int8, transpose=True)
+    mm_output_shape, K_h, K_w = get_conv2d_shapes(input.shape, result_shape, stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w)
     if padding_mode != "zeros":
         input = torch.nn.functional.pad(input, reversed_padding_repeated_twice, mode=padding_mode)
         padding_h = padding_w = 0
+    if compressed_weight_shape is not None:
+        weight = unpack_int_symetric(weight, compressed_weight_shape, weights_dtype, dtype=torch.int8, transpose=True)
 
     input, scale = quantize_int8_matmul_input(
         torch.nn.functional.unfold(
@@ -532,22 +614,66 @@ def quantized_linear_forward_int8_matmul(self, input: torch.FloatTensor) -> torc
     return int8_matmul(input, self.weight, self.bias, self.sdnq_decompressor.scale, getattr(self.sdnq_decompressor, "compressed_weight_shape", None), self.sdnq_decompressor.weights_dtype)
 
 
+def quantized_linear_forward(self, input: torch.FloatTensor) -> torch.FloatTensor:
+    return torch.nn.functional.linear(input, self.sdnq_decompressor(self.weight), self.bias)
+
+
+def get_conv2d_args(stride, padding, dilation):
+    if isinstance(stride, int):
+        stride_h = stride_w = stride
+    else:
+        stride_h, stride_w = stride
+    if isinstance(padding, int):
+        padding_h = padding_w = padding
+    else:
+        padding_h, padding_w = padding
+    if isinstance(dilation, int):
+        dilation_h = dilation_w = dilation
+    else:
+        dilation_h, dilation_w = dilation
+    return stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w
+
+
+def get_conv2d_shapes(input_shape, result_shape, stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w):
+    batch_size, _, H_in, W_in = input_shape
+    C_out, _, K_h, K_w = result_shape
+    W_out = (W_in + 2 * padding_w - dilation_w * (K_w - 1) - 1) // stride_w + 1
+    H_out = (H_in + 2 * padding_h - dilation_h * (K_h - 1) - 1) // stride_h + 1
+    return (batch_size, H_out, W_out, C_out), K_h, K_w
+
+
+def quantized_conv2d_forward_fp8_matmul(self, input) -> torch.FloatTensor:
+    stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w = get_conv2d_args(self.stride, self.padding, self.dilation)
+    return conv2d_fp8_matmul(
+        input, self.weight, self.bias,
+        self.sdnq_decompressor.scale,
+        self.sdnq_decompressor.result_shape,
+        self.sdnq_decompressor.weights_dtype,
+        self._reversed_padding_repeated_twice,
+        self.padding_mode, self.groups,
+        stride_h, stride_w,
+        padding_h, padding_w,
+        dilation_h, dilation_w,
+    )
+
+
+def quantized_conv2d_forward_fp8_matmul_tensorwise(self, input) -> torch.FloatTensor:
+    stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w = get_conv2d_args(self.stride, self.padding, self.dilation)
+    return conv2d_fp8_matmul_tensorwise(
+        input, self.weight, self.bias,
+        self.sdnq_decompressor.scale,
+        self.sdnq_decompressor.result_shape,
+        self.sdnq_decompressor.weights_dtype,
+        self._reversed_padding_repeated_twice,
+        self.padding_mode, self.groups,
+        stride_h, stride_w,
+        padding_h, padding_w,
+        dilation_h, dilation_w,
+    )
+
+
 def quantized_conv2d_forward_int8_matmul(self, input) -> torch.FloatTensor:
-    if isinstance(self.stride, int):
-        stride_h = stride_w = self.stride
-    else:
-        stride_h, stride_w = self.stride
-
-    if isinstance(self.padding, int):
-        padding_h = padding_w = self.padding
-    else:
-        padding_h, padding_w = self.padding
-
-    if isinstance(self.dilation, int):
-        dilation_h = dilation_w = self.dilation
-    else:
-        dilation_h, dilation_w = self.dilation
-
+    stride_h, stride_w, padding_h, padding_w, dilation_h, dilation_w = get_conv2d_args(self.stride, self.padding, self.dilation)
     return conv2d_int8_matmul(
         input, self.weight, self.bias,
         self.sdnq_decompressor.scale,
@@ -560,10 +686,6 @@ def quantized_conv2d_forward_int8_matmul(self, input) -> torch.FloatTensor:
         padding_h, padding_w,
         dilation_h, dilation_w,
     )
-
-
-def quantized_linear_forward(self, input: torch.FloatTensor) -> torch.FloatTensor:
-    return torch.nn.functional.linear(input, self.sdnq_decompressor(self.weight), self.bias)
 
 
 def quantized_conv_forward(self, input) -> torch.FloatTensor:
@@ -927,10 +1049,12 @@ if shared.opts.sdnq_decompress_compile:
         decompress_symmetric_compiled = torch.compile(decompress_symmetric, fullgraph=True)
         decompress_packed_int_asymmetric_compiled = torch.compile(decompress_packed_int_asymmetric, fullgraph=True)
         decompress_packed_int_symmetric_compiled = torch.compile(decompress_packed_int_symmetric, fullgraph=True)
+        int8_matmul = torch.compile(int8_matmul, fullgraph=True)
         fp8_matmul = torch.compile(fp8_matmul, fullgraph=True)
         fp8_matmul_tensorwise = torch.compile(fp8_matmul_tensorwise, fullgraph=True)
-        int8_matmul = torch.compile(int8_matmul, fullgraph=True)
         conv2d_int8_matmul = torch.compile(conv2d_int8_matmul, fullgraph=True)
+        conv2d_fp8_matmul = torch.compile(conv2d_fp8_matmul, fullgraph=True)
+        conv2d_fp8_matmul_tensorwise = torch.compile(conv2d_fp8_matmul_tensorwise, fullgraph=True)
     except Exception as e:
         shared.log.warning(f"Quantization: type=sdnq Decompress using torch.compile is not available: {e}")
         decompress_asymmetric_compiled = decompress_asymmetric

--- a/modules/model_quant_sdnq.py
+++ b/modules/model_quant_sdnq.py
@@ -405,7 +405,7 @@ def quantize_fp8_matmul_input_tensorwise(input: torch.FloatTensor, scale: torch.
     return input, scale
 
 
-def quantize_int8_matmul_input(input: torch.FloatTensor, scale: torch.FloatTensor, flatten: bool = True) -> Tuple[torch.ByteTensor, torch.FloatTensor]:
+def quantize_int8_matmul_input(input: torch.FloatTensor, scale: torch.FloatTensor) -> Tuple[torch.ByteTensor, torch.FloatTensor]:
     input = input.flatten(0,-2).contiguous()
     input_scale = torch.div(input.abs().amax(dim=-1, keepdims=True), 127)
     input = torch.div(input, input_scale).round_().clamp_(-128, 127).to(torch.int8)

--- a/modules/modeldata.py
+++ b/modules/modeldata.py
@@ -56,6 +56,10 @@ def get_model_type(pipe):
         model_type = 'mochivideo'
     elif "Allegro" in name:
         model_type = 'allegrovideo'
+    elif "PixArtSigma" in name:
+        model_type = 'pixartsigma'
+    elif "PixArtAlpha" in name:
+        model_type = 'pixartalpha'
     else:
         model_type = name
     return model_type

--- a/modules/processing_vae.py
+++ b/modules/processing_vae.py
@@ -140,8 +140,14 @@ def full_vae_decode(latents, model):
     if shift_factor:
         latents = latents + shift_factor
 
-    if getattr(model.vae, "post_quant_conv", None) is not None and "VAE" not in shared.opts.sdnq_quantize_weights:
-        latents = latents.to(next(iter(model.vae.post_quant_conv.parameters())).dtype)
+    if getattr(model.vae, "post_quant_conv", None) is not None:
+        if hasattr(model.vae.post_quant_conv, "bias"):
+            latents = latents.to(model.vae.post_quant_conv.bias.dtype)
+        else:
+            if "VAE" in shared.opts.sdnq_quantize_weights:
+                latents = latents.to(devices.dtype_vae)
+            else:
+                latents = latents.to(next(iter(model.vae.post_quant_conv.parameters())).dtype)
     else:
         latents = latents.to(model.vae.dtype)
 

--- a/modules/processing_vae.py
+++ b/modules/processing_vae.py
@@ -141,7 +141,7 @@ def full_vae_decode(latents, model):
         latents = latents + shift_factor
 
     if getattr(model.vae, "post_quant_conv", None) is not None:
-        if hasattr(model.vae.post_quant_conv, "bias"):
+        if getattr(model.vae.post_quant_conv, "bias", None) is not None:
             latents = latents.to(model.vae.post_quant_conv.bias.dtype)
         else:
             if "VAE" in shared.opts.sdnq_quantize_weights:

--- a/modules/processing_vae.py
+++ b/modules/processing_vae.py
@@ -143,11 +143,10 @@ def full_vae_decode(latents, model):
     if getattr(model.vae, "post_quant_conv", None) is not None:
         if getattr(model.vae.post_quant_conv, "bias", None) is not None:
             latents = latents.to(model.vae.post_quant_conv.bias.dtype)
+        elif "VAE" in shared.opts.sdnq_quantize_weights:
+            latents = latents.to(devices.dtype_vae)
         else:
-            if "VAE" in shared.opts.sdnq_quantize_weights:
-                latents = latents.to(devices.dtype_vae)
-            else:
-                latents = latents.to(next(iter(model.vae.post_quant_conv.parameters())).dtype)
+            latents = latents.to(next(iter(model.vae.post_quant_conv.parameters())).dtype)
     else:
         latents = latents.to(model.vae.dtype)
 

--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -902,25 +902,9 @@ def set_diffusers_attention(pipe, quiet:bool=False):
     def set_attn(pipe, attention):
         if attention is None:
             return
-        if not hasattr(pipe, "_internal_dict"):
-            return
-        modules = [getattr(pipe, n, None) for n in pipe._internal_dict.keys()] # pylint: disable=protected-access
-        modules = [m for m in modules if isinstance(m, torch.nn.Module) and hasattr(m, "set_attn_processor")]
-        for module in modules:
-            if module.__class__.__name__ in ['SD3Transformer2DModel']:
-                module.set_attn_processor(p.JointAttnProcessor2_0())
-            elif module.__class__.__name__ in ['FluxTransformer2DModel']:
-                module.set_attn_processor(p.FluxAttnProcessor2_0())
-            elif module.__class__.__name__ in ['HunyuanDiT2DModel']:
-                module.set_attn_processor(p.HunyuanAttnProcessor2_0())
-            elif module.__class__.__name__ in ['AuraFlowTransformer2DModel']:
-                module.set_attn_processor(p.AuraFlowAttnProcessor2_0())
-            elif 'KandinskyCombinedPipeline' in pipe.__class__.__name__:
-                pass
-            elif 'Transformer' in module.__class__.__name__:
-                pass # unknown transformer so probably dont want to force attention processor
-            else:
-                module.set_attn_processor(attention)
+        # other models uses their own attention processor
+        if pipe.__class__.__name__.startswith("StableDiffusion") and hasattr(pipe, "unet"):
+            pipe.unet.set_attn_processor(attention)
 
     # if hasattr(pipe, 'pipe'):
     #    set_diffusers_attention(pipe.pipe)

--- a/modules/sd_vae_taesd.py
+++ b/modules/sd_vae_taesd.py
@@ -36,7 +36,7 @@ prev_cls = ''
 prev_type = ''
 prev_model = ''
 lock = threading.Lock()
-supported = ['sd', 'sdxl', 'f1', 'h1', 'hunyuanvideo', 'wanvideo', 'mochivideo']
+supported = ['sd', 'sdxl', 'f1', 'h1', 'hunyuanvideo', 'wanvideo', 'mochivideo', 'pixartsigma', 'pixartalpha']
 
 
 def warn_once(msg, variant=None):
@@ -55,9 +55,13 @@ def get_model(model_type = 'decoder', variant = None):
     cls = shared.sd_model_type
     if cls == 'ldm': # original backend
         cls = 'sd'
-    if cls == 'h1': # hidream uses flux vae
+    elif cls == 'h1': # hidream uses flux vae
         cls = 'f1'
-    if cls not in supported:
+    elif cls == 'pixartsigma':
+        cls = 'sdxl'
+    elif cls == 'pixartalpha':
+        cls = 'sd'
+    elif cls not in supported:
         warn_once(f'cls={shared.sd_model.__class__.__name__} type={cls} unsuppported', variant=variant)
     variant = variant or shared.opts.taesd_variant
     folder = os.path.join(paths.models_path, "TAESD")

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -353,7 +353,7 @@ def get_default_modes():
                 default_offload_mode = "sequential"
                 default_diffusers_offload_min_gpu_memory = 0
                 log.info(f"Device detect: memory={gpu_memory:.1f} default=sequential optimization=lowvram")
-            elif gpu_memory <= 8:
+            elif gpu_memory <= 12:
                 cmd_opts.medvram = True # VAE Tiling and other stuff
                 default_offload_mode = "balanced"
                 default_diffusers_offload_min_gpu_memory = 0

--- a/modules/shared.py
+++ b/modules/shared.py
@@ -521,10 +521,11 @@ options_templates.update(options_section(("quantization", "Quantization Settings
     "sdnq_quantize_weights_mode": OptionInfo("int8", "Quantization type", gr.Dropdown, {"choices": ["int8", "int6", "uint4", "float8_e4m3fn", "uint8", "uint6", "int4", "float8_e5m2", "float8_e4m3fnuz", "float8_e5m2fnuz", "int2", "uint2", "uint1"], "visible": native}),
     "sdnq_quantize_weights_group_size": OptionInfo(0, "Group size", gr.Slider, {"minimum": -1, "maximum": 4096, "step": 1, "visible": native}),
     "sdnq_quantize_conv_layers": OptionInfo(False, "Quantize the convolutional layers", gr.Checkbox, {"visible": native}),
-    "sdnq_decompress_fp32": OptionInfo(False, "Decompress using full precision", gr.Checkbox, {"visible": native}),
     "sdnq_decompress_compile": OptionInfo(devices.has_triton(), "Decompress using torch.compile", gr.Checkbox, {"visible": native}),
     "sdnq_use_quantized_matmul": OptionInfo(False, "Use Quantized MatMul", gr.Checkbox, {"visible": native}),
+    "sdnq_use_quantized_matmul_conv": OptionInfo(False, "Use Quantized MatMul with convolutional layers", gr.Checkbox, {"visible": native}),
     "sdnq_quantize_with_gpu": OptionInfo(True, "Quantize with the GPU", gr.Checkbox, {"visible": native}),
+    "sdnq_decompress_fp32": OptionInfo(False, "Decompress using full precision", gr.Checkbox, {"visible": native}),
     "sdnq_quantize_shuffle_weights": OptionInfo(False, "Shuffle weights in post mode", gr.Checkbox, {"visible": native}),
 
     "bnb_quantization_sep": OptionInfo("<h2>BitsAndBytes</h2>", "", gr.HTML),


### PR DESCRIPTION
When loading lycoris, the following gets wrongfully logged even if the lycoris actually loaded with no errors:

```
21:08:19-276491 ERROR    Network load: type=LoRA name="<some lycoris>"
                         file="/home/ml/stable-diffusion-webui/models/Lora/<some lycoris>.safetensors" errors=350
                         empty module
```

This happens because module_errors increments for *each* attempted create_module on every key. However instead it should only increment if *all* create_module attempts failed for that key.

Since the first nettype is lora and lora will always fail on lycoris weights, module_errors gets increment on every key even if these keys load successfully later when the correct lycoris network's nettype.create_module is called 