### PR TITLE
Fix colliding hashes for direct download diffusers models

### DIFF
--- a/modules/modelloader.py
+++ b/modules/modelloader.py
@@ -326,7 +326,7 @@ def load_diffusers_models(clear=True):
                 folder = os.path.join(place, folder)
                 friendly = os.path.join(place, name)
                 if os.path.exists(os.path.join(folder, 'model_index.json')): # direct download of diffusers model
-                    repo = { 'name': name, 'filename': name, 'friendly': friendly, 'folder': folder, 'path': folder, 'hash': '', 'mtime': os.path.getmtime(folder), 'model_info': os.path.join(folder, 'model_info.json'), 'model_index': os.path.join(folder, 'model_index.json') }
+                    repo = { 'name': name, 'filename': name, 'friendly': friendly, 'folder': folder, 'path': folder, 'hash': None, 'mtime': os.path.getmtime(folder), 'model_info': os.path.join(folder, 'model_info.json'), 'model_index': os.path.join(folder, 'model_index.json') }
                     diffuser_repos.append(repo)
                     continue
                 snapshots = os.listdir(os.path.join(folder, "snapshots"))


### PR DESCRIPTION
Models directly downloaded in diffusers format (which are not downloaded with huggingface_hub and do not have e.g. snapshots folders) will share the same empty string hash. Since all hash exists checks are based on None only, this will result in the empty string hashes conflicting and overwriting each other.

A direct result of this is that only one direct download diffusers model can be listed.

Before:
![image](https://github.com/user-attachments/assets/015af86f-002e-4fb4-9c31-3b3aa5d33654)


After:
![image](https://github.com/user-attachments/assets/4118fa31-48b1-46bc-aa64-443dd718efb6)
