### PR TITLE
Update gallery.js

### DIFF
--- a/javascript/gallery.js
+++ b/javascript/gallery.js
@@ -54,6 +54,70 @@ class GalleryFolder extends HTMLElement {
   }
 }
 
+// Add CSS for collapsible separators
+function addSeparatorStyles() {
+  if (document.getElementById('gallery-separator-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'gallery-separator-styles';
+  // FIX: Use existing theme variables and adjust flex properties for spacing.
+  style.textContent = `
+    .gallery-separator {
+      cursor: pointer;
+      padding: 8px 12px;
+      margin: 4px 0;
+      background-color: var(--sd-group-background-color, #2c2c2c);
+      color: var(--sd-input-text-color, #e0e0e0);
+      border-radius: 4px;
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      user-select: none;
+      transition: background-color 0.2s;
+    }
+    .gallery-separator:hover {
+      background-color: var(--sd-panel-background-color, #444);
+    }
+    .gallery-separator-title {
+      flex-grow: 1; /* Changed from flex: 1 */
+      margin-right: 8px; /* Added margin for spacing */
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .gallery-separator-icon {
+      font-family: monospace;
+      font-size: 14px;
+      width: 16px;
+      text-align: center;
+      transition: transform 0.2s ease;
+      display: inline-block;
+      transform-origin: center;
+      transform: rotate(90deg);
+    }
+    .gallery-separator.collapsed .gallery-separator-icon {
+      transform: rotate(0deg);
+    }
+    .gallery-separator-count {
+      font-size: 12px;
+      color: var(--sd-label-color, #b0b0b0);
+      font-weight: normal;
+      margin-left: auto; /* Keeps it to the right */
+      flex-shrink: 0; /* Prevents count from shrinking */
+    }
+    .gallery-section {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      overflow: hidden;
+    }
+    .gallery-section.collapsed {
+      display: none !important;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
 async function createThumb(img) {
   const height = opts.extra_networks_card_size;
   const width = opts.browser_fixed_width ? opts.extra_networks_card_size : 0;
@@ -71,25 +135,39 @@ async function createThumb(img) {
   return dataURL;
 }
 
-async function addSeparators() {
-  document.querySelectorAll('.gallery-separator').forEach((node) => el.files.removeChild(node));
-  const all = Array.from(el.files.children);
-  let lastDir;
-  for (const f of all) {
-    let dir = f.name.match(/(.*)[\/\\]/);
-    if (!dir) dir = '';
-    else dir = dir[1];
-    if (dir !== lastDir) {
-      lastDir = dir;
-      if (dir.length > 0) {
-        const sep = document.createElement('div');
-        sep.className = 'gallery-separator';
-        sep.innerText = dir;
-        sep.title = dir;
-        el.files.insertBefore(sep, f);
-      }
-    }
+// Load collapsed state from localStorage
+function loadCollapsedState() {
+  try {
+    const state = localStorage.getItem('gallery-collapsed-sections');
+    return state ? JSON.parse(state) : {};
+  } catch {
+    return {};
   }
+}
+
+// Check if a section has been explicitly set to expanded
+function isSectionExpanded(sectionName) {
+  const state = loadCollapsedState();
+  // If no state is saved, default to collapsed (true)
+  // If state exists, use it (false = expanded, true = collapsed)
+  // TODO: I didn't end up liking this function, but I already wrote it, need to make it a setting
+  return state.hasOwnProperty(sectionName) ? !state[sectionName] : false;
+}
+
+// Save collapsed state to localStorage
+function saveCollapsedState(sectionName, isCollapsed) {
+  try {
+    const state = loadCollapsedState();
+    state[sectionName] = isCollapsed;
+    localStorage.setItem('gallery-collapsed-sections', JSON.stringify(state));
+  } catch {
+    // Ignore localStorage errors
+  }
+}
+
+// This function is no longer used after the refactor, kept for compatibility
+async function addSeparators() {
+  // Function stub - separators are now created during file loading
 }
 
 async function delayFetchThumb(fn) {
@@ -126,9 +204,16 @@ class GalleryFile extends HTMLElement {
   }
 
   async connectedCallback() {
+    // Skip if already loaded
     if (this.shadow.children.length > 0) {
       return;
     }
+    
+    // Check if this element has a data-skip-load attribute
+    if (this.dataset.skipLoad === 'true') {
+      return;
+    }
+    
     const ext = this.name.split('.').pop().toLowerCase();
     if (!['jpg', 'jpeg', 'png', 'gif', 'webp', 'jxl', 'svg', 'mp4'].includes(ext)) {
       // console.error(`gallery: type=${ext} file=${this.name} unsupported`);
@@ -255,11 +340,28 @@ async function gallerySearch(evt) {
   if (el.search.busy) clearTimeout(el.search.busy);
   el.search.busy = setTimeout(async () => {
     let numFound = 0;
-    const all = Array.from(el.files.children);
     const str = el.search.value.toLowerCase();
     const r = /^(.+)([=<>])(.*)/;
     const t0 = performance.now();
-    for (const f of all) {
+    
+    // If searching, ensure all sections are loaded
+    if (str.length > 0) {
+      const sections = document.querySelectorAll('.gallery-section');
+      for (const section of sections) {
+        if (section.dataset.loaded === 'false') {
+          section.dataset.loaded = 'true';
+          const images = section.querySelectorAll('gallery-file');
+          for (const img of images) {
+            delete img.dataset.skipLoad;
+            await img.connectedCallback();
+          }
+        }
+      }
+    }
+    
+    // Search through all gallery-file elements
+    const allFiles = el.files.querySelectorAll('gallery-file');
+    for (const f of allFiles) {
       if (r.test(str)) {
         const match = str.match(r);
         const key = match[1].trim();
@@ -278,9 +380,10 @@ async function gallerySearch(evt) {
       } else {
         f.style.display = 'none';
       }
-      const t1 = performance.now();
-      el.status.innerText = `Filter | ${f.folder} | ${numFound.toLocaleString()}/${all.length.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`;
     }
+    
+    const t1 = performance.now();
+    el.status.innerText = `Filter | ${numFound.toLocaleString()}/${allFiles.length.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`;
   }, 250);
 }
 
@@ -296,75 +399,118 @@ const findDuplicates = (arr, key) => {
 
 async function gallerySort(btn) {
   const t0 = performance.now();
-  const arr = Array.from(el.files.children).filter((node) => node.name); // filter out separators
-  if (arr.length === 0) return; // no files to sort
+  
+  // Collect all files from all sections and root
+  const allFiles = [];
+  
+  // Get root files (not in any section)
+  el.files.querySelectorAll(':scope > gallery-file').forEach(file => {
+    file.sectionName = '';
+    file.wasLoaded = true; // Root files are always loaded
+    allFiles.push(file);
+  });
+  
+  // Get files from sections
+  const sections = document.querySelectorAll('.gallery-section');
+  sections.forEach(section => {
+    const files = Array.from(section.querySelectorAll('gallery-file'));
+    files.forEach(file => {
+      file.sectionName = section.dataset.sectionName;
+      file.wasLoaded = !file.dataset.skipLoad;
+      allFiles.push(file);
+    });
+  });
+  
+  if (allFiles.length === 0) return;
   if (btn) lastSort = btn.charCodeAt(0);
   lastSortName = 'none';
-  const fragment = document.createDocumentFragment();
+  
+  // Sort the files
   switch (lastSort) {
     case 61789: // name asc
       lastSortName = 'name asc';
-      arr
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((a, b) => a.name.localeCompare(b.name));
       break;
     case 61790: // name dsc
       lastSortName = 'name dsc';
-      arr
-        .sort((b, a) => a.name.localeCompare(b.name))
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((b, a) => a.name.localeCompare(b.name));
       break;
     case 61792: // size asc
       lastSortName = 'size asc';
-      arr
-        .sort((a, b) => a.size - b.size)
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((a, b) => a.size - b.size);
       break;
     case 61793: // size dsc
       lastSortName = 'size dsc';
-      arr
-        .sort((b, a) => a.size - b.size)
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((b, a) => a.size - b.size);
       break;
     case 61794: // resolution asc
       lastSortName = 'resolution asc';
-      arr
-        .sort((a, b) => a.width * a.height - b.width * b.height)
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((a, b) => a.width * a.height - b.width * b.height);
       break;
     case 61795: // resolution dsc
       lastSortName = 'resolution dsc';
-      arr
-        .sort((b, a) => a.width * a.height - b.width * b.height)
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((b, a) => a.width * a.height - b.width * b.height);
       break;
     case 61662:
       lastSortName = 'modified asc';
-      arr
-        .sort((a, b) => a.mtime - b.mtime)
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((a, b) => a.mtime - b.mtime);
       break;
     case 61661:
       lastSortName = 'modified dsc';
-      arr
-        .sort((b, a) => a.mtime - b.mtime)
-        .forEach((node) => fragment.appendChild(node));
+      allFiles.sort((b, a) => a.mtime - b.mtime);
       break;
     default:
-      break;
+      return;
   }
-  if (fragment.children.length === 0) return;
-  el.files.innerHTML = '';
-  el.files.appendChild(fragment);
-  addSeparators();
+  
+  // Clear sections and remove root files
+  el.files.querySelectorAll(':scope > gallery-file').forEach(file => file.remove());
+  sections.forEach(section => {
+    section.innerHTML = '';
+  });
+  
+  // Redistribute files
+  allFiles.forEach(file => {
+    if (file.sectionName === '') {
+      // Root file - find the right position among separators
+      const separators = Array.from(el.files.querySelectorAll('.gallery-separator'));
+      if (separators.length > 0) {
+        el.files.insertBefore(file, separators[0]);
+      } else {
+        el.files.appendChild(file);
+      }
+    } else {
+      // Section file
+      const section = Array.from(sections).find(s => s.dataset.sectionName === file.sectionName);
+      if (section) {
+        // Restore skipLoad state if file wasn't loaded
+        if (!file.wasLoaded) {
+          file.dataset.skipLoad = 'true';
+        }
+        section.appendChild(file);
+      }
+    }
+  });
+  
+  // Update counts
+  sections.forEach(section => {
+    const count = section.children.length;
+    const sectionName = section.dataset.sectionName;
+    const separator = Array.from(document.querySelectorAll('.gallery-separator')).find(
+      sep => sep.querySelector('span:nth-child(2)').textContent === sectionName
+    );
+    if (separator) {
+      separator.querySelector('.gallery-separator-count').textContent = `${count} files`;
+    }
+  });
+  
   const t1 = performance.now();
-  log(`gallerySort: char=${lastSort} len=${arr.length} time=${Math.floor(t1 - t0)} sort=${lastSortName}`);
-  el.status.innerText = `Sort | ${lastSortName} | ${arr.length.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`;
+  log(`gallerySort: char=${lastSort} len=${allFiles.length} time=${Math.floor(t1 - t0)} sort=${lastSortName}`);
+  el.status.innerText = `Sort | ${lastSortName} | ${allFiles.length.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`;
 }
 
 async function fetchFilesHT(evt) {
   const t0 = performance.now();
-  const fragment = document.createDocumentFragment();
   el.status.innerText = `Folder | ${evt.target.name} | in-progress`;
   let numFiles = 0;
 
@@ -374,19 +520,134 @@ async function fetchFilesHT(evt) {
     return;
   }
   const jsonData = await res.json();
+  
+  // Collect all files first
+  const allFiles = [];
   for (const line of jsonData) {
     const data = decodeURI(line).split('##F##');
     numFiles++;
     const f = new GalleryFile(data[0], data[1]);
-    fragment.appendChild(f);
+    allFiles.push(f);
+  }
+  
+  // Sort files by name to ensure proper grouping
+  allFiles.sort((a, b) => a.name.localeCompare(b.name));
+  
+  // Organize files by directory
+  const filesByDir = new Map();
+  for (const f of allFiles) {
+    let dir = f.name.match(/(.*)[\/\\]/);
+    if (!dir) dir = '';
+    else dir = dir[1];
+    
+    if (!filesByDir.has(dir)) {
+      filesByDir.set(dir, []);
+    }
+    filesByDir.get(dir).push(f);
   }
 
-  el.files.appendChild(fragment);
+  // Now add organized files with separators
+  addSeparatorStyles();
+  el.files.innerHTML = '';
+  
+  // Handle files without directories first
+  const rootFiles = filesByDir.get('');
+  if (rootFiles && rootFiles.length > 0) {
+    rootFiles.forEach(file => {
+      el.files.appendChild(file);
+      // Root files should always load immediately
+      file.connectedCallback();
+    });
+  }
+  
+  // Sort directory names for consistent display
+  const sortedDirs = Array.from(filesByDir.keys())
+    .filter(dir => dir.length > 0)
+    .sort((a, b) => a.localeCompare(b));
+  
+  for (const dir of sortedDirs) {
+    const files = filesByDir.get(dir);
+    
+    // Create separator
+    const sep = document.createElement('div');
+    sep.className = 'gallery-separator collapsed'; // Start collapsed
+    
+    const icon = document.createElement('span');
+    icon.className = 'gallery-separator-icon';
+    icon.textContent = '▶';
+    
+    const text = document.createElement('span');
+    text.className = 'gallery-separator-title';
+    text.textContent = dir;
+    
+    const count = document.createElement('span');
+    count.className = 'gallery-separator-count';
+    count.textContent = `${files.length} files`;
+    
+    sep.appendChild(icon);
+    sep.appendChild(text);
+    sep.appendChild(count);
+    sep.title = `Click to toggle ${dir}`;
+    
+    // Create section container
+    const section = document.createElement('div');
+    section.className = 'gallery-section collapsed'; // Start collapsed
+    section.dataset.sectionName = dir;
+    section.dataset.loaded = 'false';
+    
+    // Add files to section with skipLoad
+    files.forEach(file => {
+      file.dataset.skipLoad = 'true';
+      section.appendChild(file);
+    });
+    
+    // Check if section should be expanded
+    const isExpanded = isSectionExpanded(dir);
+    if (isExpanded) {
+      sep.classList.remove('collapsed');
+      section.classList.remove('collapsed');
+      section.dataset.loaded = 'true';
+      // Load images for expanded sections
+      files.forEach(file => {
+        delete file.dataset.skipLoad;
+        file.connectedCallback();
+      });
+    }
+    
+    // Add click handler
+    sep.addEventListener('click', async () => {
+      const isCollapsed = sep.classList.toggle('collapsed');
+      section.classList.toggle('collapsed');
+      saveCollapsedState(dir, isCollapsed);
+      
+      // Load images when expanding for the first time
+      if (!isCollapsed && section.dataset.loaded === 'false') {
+        section.dataset.loaded = 'true';
+        const countSpan = sep.querySelector('.gallery-separator-count');
+        const originalText = countSpan.textContent;
+        countSpan.textContent = 'Loading...';
+        
+        const images = section.querySelectorAll('gallery-file');
+        let loaded = 0;
+        for (const img of images) {
+          delete img.dataset.skipLoad;
+          await img.connectedCallback();
+          loaded++;
+          if (loaded % 5 === 0) {
+            countSpan.textContent = `Loading... ${loaded}/${images.length}`;
+          }
+        }
+        countSpan.textContent = originalText;
+      }
+    });
+    
+    el.files.appendChild(sep);
+    el.files.appendChild(section);
+  }
 
   const t1 = performance.now();
   log(`gallery: folder=${evt.target.name} num=${numFiles} time=${Math.floor(t1 - t0)}ms`);
   el.status.innerText = `Folder | ${evt.target.name} | ${numFiles.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`;
-  addSeparators();
 }
 
 async function fetchFilesWS(evt) { // fetch file-by-file list over websockets
@@ -410,31 +671,145 @@ async function fetchFilesWS(evt) { // fetch file-by-file list over websockets
   const t0 = performance.now();
   let numFiles = 0;
   let t1 = performance.now();
-  let fragment = document.createDocumentFragment();
+  
+  // Collect files by directory
+  const filesByDir = new Map();
+  const pendingFiles = [];
 
   ws.onmessage = (event) => {
+    numFiles++;
     t1 = performance.now();
     const data = decodeURI(event.data).split('##F##');
     if (data[0] === '#END#') {
       ws.close();
     } else {
       const file = new GalleryFile(data[0], data[1]);
-      numFiles++;
-      fragment.appendChild(file);
+      pendingFiles.push(file);
+      
       if (numFiles % 100 === 0) {
         el.status.innerText = `Folder | ${evt.target.name} | ${numFiles.toLocaleString()} images | in-progress | ${Math.floor(t1 - t0).toLocaleString()}ms`;
-        el.files.appendChild(fragment);
-        fragment = document.createDocumentFragment();
       }
     }
   };
+  
   ws.onclose = (event) => {
-    el.files.appendChild(fragment);
-    // gallerySort();
+    // Sort files by name to ensure proper grouping
+    pendingFiles.sort((a, b) => a.name.localeCompare(b.name));
+    
+    // Organize all files by directory
+    for (const file of pendingFiles) {
+      let dir = file.name.match(/(.*)[\/\\]/);
+      if (!dir) dir = '';
+      else dir = dir[1];
+      
+      if (!filesByDir.has(dir)) {
+        filesByDir.set(dir, []);
+      }
+      filesByDir.get(dir).push(file);
+    }
+    
+    // Now add organized files with separators
+    addSeparatorStyles();
+    
+    // Handle files without directories first
+    const rootFiles = filesByDir.get('');
+    if (rootFiles && rootFiles.length > 0) {
+      rootFiles.forEach(file => {
+        el.files.appendChild(file);
+        // Root files should always load immediately
+        file.connectedCallback();
+      });
+    }
+    
+    // Sort directory names for consistent display
+    const sortedDirs = Array.from(filesByDir.keys())
+      .filter(dir => dir.length > 0)
+      .sort((a, b) => a.localeCompare(b));
+    
+    for (const dir of sortedDirs) {
+      const files = filesByDir.get(dir);
+      
+      // Create separator
+      const sep = document.createElement('div');
+      sep.className = 'gallery-separator collapsed';
+      
+      const icon = document.createElement('span');
+      icon.className = 'gallery-separator-icon';
+      icon.textContent = '▶';
+      
+      const text = document.createElement('span');
+      text.className = 'gallery-separator-title';
+      text.textContent = dir;
+      
+      const count = document.createElement('span');
+      count.className = 'gallery-separator-count';
+      count.textContent = `${files.length} files`;
+      
+      sep.appendChild(icon);
+      sep.appendChild(text);
+      sep.appendChild(count);
+      sep.title = `Click to toggle ${dir}`;
+      
+      // Create section container
+      const section = document.createElement('div');
+      section.className = 'gallery-section collapsed';
+      section.dataset.sectionName = dir;
+      section.dataset.loaded = 'false';
+      
+      // Add files to section with skipLoad
+      files.forEach(file => {
+        file.dataset.skipLoad = 'true';
+        section.appendChild(file);
+      });
+      
+      // Check if section should be expanded
+      const isExpanded = isSectionExpanded(dir);
+      if (isExpanded) {
+        sep.classList.remove('collapsed');
+        section.classList.remove('collapsed');
+        section.dataset.loaded = 'true';
+        // Load images for expanded sections
+        files.forEach(file => {
+          delete file.dataset.skipLoad;
+          file.connectedCallback();
+        });
+      }
+      
+      // Add click handler
+      sep.addEventListener('click', async () => {
+        const isCollapsed = sep.classList.toggle('collapsed');
+        section.classList.toggle('collapsed');
+        saveCollapsedState(dir, isCollapsed);
+        
+        // Load images when expanding for the first time
+        if (!isCollapsed && section.dataset.loaded === 'false') {
+          section.dataset.loaded = 'true';
+          const countSpan = sep.querySelector('.gallery-separator-count');
+          const originalText = countSpan.textContent;
+          countSpan.textContent = 'Loading...';
+          
+          const images = section.querySelectorAll('gallery-file');
+          let loaded = 0;
+          for (const img of images) {
+            delete img.dataset.skipLoad;
+            await img.connectedCallback();
+            loaded++;
+            if (loaded % 5 === 0) {
+              countSpan.textContent = `Loading... ${loaded}/${images.length}`;
+            }
+          }
+          countSpan.textContent = originalText;
+        }
+      });
+      
+      el.files.appendChild(sep);
+      el.files.appendChild(section);
+    }
+    
     log(`gallery: folder=${evt.target.name} num=${numFiles} time=${Math.floor(t1 - t0)}ms`);
     el.status.innerText = `Folder | ${evt.target.name} | ${numFiles.toLocaleString()} images | ${Math.floor(t1 - t0).toLocaleString()}ms`;
-    addSeparators();
   };
+
   ws.onerror = (event) => {
     log('gallery ws error', event);
   };


### PR DESCRIPTION
New collapsible separators, file count, lazy loading

## Description

Old separators were static and with many subfolders and many images the gallery was difficult to navigate. Now, the separators are collapsible, lazy loading has been introduced so that thumbnails are not loaded until a separator is opened, separators also feature a file count.

## Notes

This ended up being a little bit more involved than I originally expected, so apologies if it's not the most elegant code. Tested extensively with huge image libraries with no discernible performance hit as compared to before. Whenever possible I avoided altering the original code.

## Environment and Testing

Developed on Ubuntu 22.04, tested on Windows 11 24H2. Tested with small and huge (more than 40 thousand images) libraries of images. Tested on Edge, Mozilla Firefox and Chrome.

I have a limited ability to test mobile devices but works without any issues on my Samsung S25 Ultra.