### PR TITLE
Fix: Invalid wheel URL when installing Nunchaku on Windows

### DIFF
--- a/modules/mit_nunchaku.py
+++ b/modules/mit_nunchaku.py
@@ -52,7 +52,7 @@ def install_nunchaku():
         url = os.environ.get('NUNCHAKU_COMMAND', None)
         if url is None:
             url = f'https://huggingface.co/mit-han-lab/nunchaku/resolve/main/nunchaku-{ver}'
-            url += f'+torch{torch_ver}-cp{python_ver}-cp{python_ver}-{arch}_{suffix}.whl'
+            url += f'+torch{torch_ver}-cp{python_ver}-cp{python_ver}-{suffix}.whl'
         cmd = f'install --upgrade {url}'
         # pip install https://huggingface.co/mit-han-lab/nunchaku/resolve/main/nunchaku-0.2.0+torch2.6-cp311-cp311-linux_x86_64.whl
         log.debug(f'Nunchaku: install="{url}"')


### PR DESCRIPTION
## Description

The install script generated a non-existent URL by including an incorrect {arch}_ prefix in the wheel filename.

This PR removes {arch}_, fixing the installation of Nunchaku on Windows platform.

## Notes

Result before: 
"https://huggingface.co/mit-han-lab/nunchaku/resolve/main/nunchaku-0.3.1+torch2.7-cp311-cp311-windows_win_amd64.whl"

Result after:
"https://huggingface.co/mit-han-lab/nunchaku/resolve/main/nunchaku-0.3.1+torch2.7-cp311-cp311-win_amd64.whl"
