### PR TITLE
Add seed reuse to Control

### DIFF
--- a/modules/control/run.py
+++ b/modules/control/run.py
@@ -277,6 +277,8 @@ def control_run(state: str = '', # pylint: disable=keyword-arg-before-vararg
         inputs = [None]
     output_images: List[Image.Image] = [] # output images
     processed_image: Image.Image = None # last processed image
+    info_txt = []
+    generation_info_js = ''
     if mask is not None and input_type == 0:
         input_type = 1 # inpaint always requires control_image
 
@@ -573,6 +575,7 @@ def control_run(state: str = '', # pylint: disable=keyword-arg-before-vararg
                         if processed is not None:
                             output = processed.images
                             info_txt = [processed.infotext(p, i) for i in range(len(output))]
+                            generation_info_js = processed.js()
 
                         # output = pipe(**vars(p)).images # alternative direct pipe exec call
                     else: # blend all processed images and return
@@ -593,7 +596,7 @@ def control_run(state: str = '', # pylint: disable=keyword-arg-before-vararg
                                     msg = f'Control output | {index} of {frames} skip {video_skip_frames} | Frame {image_txt}'
                                 else:
                                     msg = f'Control output | {index} of {len(inputs)} | Image {image_txt}'
-                                yield (output_image, blended_image, msg) # result is control_output, proces_output
+                                yield (output_image, blended_image, '', msg, None) # control_output, proces_output
 
                 if video is not None and frame is not None:
                     status, frame = video.read()
@@ -633,5 +636,5 @@ def control_run(state: str = '', # pylint: disable=keyword-arg-before-vararg
     if len(info_txt) > 0:
         html_txt = html_txt + infotext_to_html(info_txt[0])
     if is_generator:
-        yield (output_images, blended_image, html_txt, output_filename)
-    return (output_images, blended_image, html_txt, output_filename)
+        yield (output_images, blended_image, generation_info_js, html_txt, output_filename)
+    return (output_images, blended_image, generation_info_js, html_txt, output_filename)

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -348,16 +348,19 @@ def create_override_inputs(tab): # pylint: disable=unused-argument
 
 
 def connect_reuse_seed(seed: gr.Number, reuse_seed: gr.Button, generation_info: gr.Textbox, is_subseed, subseed_strength=None):
-    """ Connects a 'reuse (sub)seed' button's click event so that it copies last used
-        (sub)seed value from generation info the to the seed field. If copying subseed and subseed strength
-        was 0, i.e. no variation seed was used, it copies the normal seed value instead."""
+    """Connect a "reuse seed" button so it copies the seed from the last
+    generation back into the seed field.
+
+    Works with both image and video results across txt2img, img2img and
+    control tabs. If copying subseed and subseed strength was 0 (no
+    variation seed used), the normal seed value is copied instead."""
     def copy_seed(gen_info_string: str, index: int):
         restore_seed = -1
         restore_strength = -1
         try:
             gen_info = json.loads(gen_info_string)
             shared.log.debug(f'Reuse: info={gen_info}')
-            index -= gen_info.get('index_of_first_image', 0)
+            index -= gen_info.get('index_of_first_image', gen_info.get('index_of_first_frame', 0))
             index = int(index)
             if is_subseed:
                 all_subseeds = gen_info.get('all_subseeds', [-1])


### PR DESCRIPTION
Extend seed reuse support to the Control tab by plumbing generation metadata through the pipeline and UI, adding consistent seed/subseed reuse for images and videos.