### PR TITLE
Actually terminate wildcard parents() at wildcards_dir

### DIFF
--- a/modules/ui_extra_networks_wildcards.py
+++ b/modules/ui_extra_networks_wildcards.py
@@ -12,7 +12,7 @@ class ExtraNetworksPageWildcards(ui_extra_networks.ExtraNetworksPage):
 
     def parents(self, file):
         folder = os.path.dirname(file)
-        if folder != shared.opts.wildcards_dir and folder not in wildcards_list:
+        if folder != os.path.abspath(shared.opts.wildcards_dir) and folder not in wildcards_list:
             wildcards_list.append(folder)
             self.parents(folder)
 


### PR DESCRIPTION
## Description
This fixes one cause of getting bogged down at "UI initialize: txt2img".

## Notes
The current `parents()` function doesn't properly stop at the wildcards directory when the directory is a relative path (as is default!) which then results in calling `modelstats.stat()` on the entire filesystem (plus redundant `os.walk()` calls for each level on the way there), if there is a wildcard file present to get it going.

n.b. I'm not actually sure what the value is of finding the ancestors and giving them their own square entries in the UI; another fix would just be deleting `parents()` entirely.

## Environment and Testing
I observed the bad behavior on both Windows and Linux, tested this specific fix on the latter only.