### PR TITLE
Flex.2: fix pipeline bug that forces contol in inpaint

### DIFF
--- a/pipelines/flex2/__init__.py
+++ b/pipelines/flex2/__init__.py
@@ -291,7 +291,7 @@ class Flex2Pipeline(FluxControlPipeline):
             )
             inpaint_image = self.vae.encode(inpaint_image).latent_dist.sample(generator=generator)
             inpaint_latents = (inpaint_image - self.vae.config.shift_factor) * self.vae.config.scaling_factor
-            height_inpaint_image, width_inpaint_image = control_image.shape[2:]
+            height_inpaint_image, width_inpaint_image = inpaint_image.shape[2:]
 
             inpaint_mask = self.prepare_image(
                 image=inpaint_mask,


### PR DESCRIPTION
## Description

Flex.2 pipeline has a bug that forces use of a control image alongside inpaint image. This should fix this

This fix comes from HF user katuni4ka

Link: https://huggingface.co/ostris/Flex.2-preview/discussions/16

## Notes

This only fixes the FLex.2 pipeline itself. Other components of SD.Next might need to be changed to make use of inpaint without control
