### PR TITLE
Fix some stuff for ROCm on Windows

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -720,7 +720,7 @@ def install_rocm_zluda():
     if sys.platform == "win32":
         #check_python(supported_minors=[10, 11, 12, 13], reason='ZLUDA backend requires a Python version between 3.10 and 3.13')
 
-        if args.use_rocm and args.experimental and (sys.version_info.major, sys.version_info.minor) == (3, 12): # TODO install: switch to pytorch source when it becomes available
+        if args.use_rocm and args.experimental and sys.version_info.major == 3 and sys.version_info.minor >= 12: # TODO install: switch to pytorch source when it becomes available
             torch_command = os.environ.get('TORCH_COMMAND', '--no-cache-dir https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torch-2.8.0a0%2Bgitfc14c65-cp312-cp312-win_amd64.whl https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torchvision-0.24.0a0%2Bc85f008-cp312-cp312-win_amd64.whl')
         else:
             if args.device_id is not None:

--- a/modules/rocm.py
+++ b/modules/rocm.py
@@ -149,7 +149,10 @@ if sys.platform == "win32":
         return os.path.join(hip_path, str(latest))
 
     def get_version() -> str:
-        return spawn("hipconfig --version", cwd=os.path.join(path, 'Scripts'))
+        try:
+            return spawn("hipconfig --version", cwd=os.path.join(path, 'Scripts'))
+        except:
+            return os.path.basename(path) or os.path.basename(os.path.dirname(path))
 
     def get_agents() -> List[Agent]:
         return [Agent(x.split(' ')[-1].strip()) for x in spawn("hipinfo", cwd=os.path.join(path, 'Scripts')).split("\n") if x.startswith('gcnArchName:')]

--- a/modules/rocm.py
+++ b/modules/rocm.py
@@ -148,11 +148,11 @@ if sys.platform == "win32":
 
         return os.path.join(hip_path, str(latest))
 
-    def get_version() -> str: # cannot just run hipconfig as it requires Perl installed on Windows.
-        return os.path.basename(path) or os.path.basename(os.path.dirname(path))
+    def get_version() -> str:
+        return spawn("hipconfig --version", cwd=os.path.join(path, 'Scripts'))
 
     def get_agents() -> List[Agent]:
-        return [Agent(x.split(' ')[-1].strip()) for x in spawn("hipinfo", cwd=os.path.join(path, 'bin')).split("\n") if x.startswith('gcnArchName:')]
+        return [Agent(x.split(' ')[-1].strip()) for x in spawn("hipinfo", cwd=os.path.join(path, 'Scripts')).split("\n") if x.startswith('gcnArchName:')]
 
     is_wsl: bool = False
     version_torch = None


### PR DESCRIPTION
## Description

- Allow using Python 3.13 and 3.14 with ROCm.
- Fix ROCm on Windows using `Scripts` folder in `.venv` instead of `bin`
- Properly implement the Windows version of `rocm.get_version()`

## Notes

Just tried using [TheRock](https://github.com/ROCm/TheRock) to generate images without ZLUDA on Windows. Had to fix some small stuff like ROCm only allow Python 3.12 and the renaming of bin to Scripts in the .venv folder. The function `rocm.get_version()` now seems to work on Windows aswell as `hipconfig` runs on my machine without having perl installed.

## Environment and Testing

Windows 11, Python 3.13
