### PR TITLE
Fix HIP library detection (ROCm)

### DIFF
--- a/modules/rocm.py
+++ b/modules/rocm.py
@@ -59,7 +59,13 @@ class ROCmEnvironment(Environment):
                     super().__init__(lib)
                     break
         else:
-            super().__init__(os.path.join(path, "lib", "libamdhip64.so"))
+            # Check 64bit path first, then fall back if it doesn't exist
+            # FIXME: This may be brittle on Debian-based distributions
+            joined_path = os.path.join(path, "lib64", "libamdhip64.so")
+            if not os.path.exists(joined_path):
+                joined_path = os.path.join(path, "lib", "libamdhip64.so")
+
+            super().__init__(joined_path)
         self.path = path
 
 


### PR DESCRIPTION
## Description

The code unconditionally checked `lib`, but on modern Linux distributions, 64-bit binaries are under `lib64` instead. So, first check under `lib64` and if the path doesn't exist, fall back to `lib` (existing behavior)

## Notes

Note that this might be slightly different on Debian-based distributions, but as I don't have one I can't test it.

## Environment and Testing

openSUSE Tumbleweed + ROCm 6.4.
