### PR TITLE
Added option to randomize loopback iterations

### DIFF
--- a/scripts/loopback.py
+++ b/scripts/loopback.py
@@ -1,4 +1,5 @@
 import math
+import random
 
 import gradio as gr
 from modules import images, processing, scripts_manager
@@ -21,10 +22,12 @@ class Script(scripts_manager.Script):
             final_denoising_strength = gr.Slider(minimum=0, maximum=1, step=0.01, label='Final strength', value=0.5, elem_id=self.elem_id("final_denoising_strength"))
         with gr.Row():
             denoising_curve = gr.Dropdown(label="Strength curve", choices=["Aggressive", "Linear", "Lazy"], value="Linear")
+        with gr.Row():
+            randomize_seed = gr.Checkbox(label="Randomize seed after each loop iteration", value=False)
 
-        return [loops, final_denoising_strength, denoising_curve]
+        return [loops, final_denoising_strength, denoising_curve, randomize_seed]
 
-    def run(self, p, loops, final_denoising_strength, denoising_curve): # pylint: disable=arguments-differ
+    def run(self, p, loops, final_denoising_strength, denoising_curve, randomize_seed): # pylint: disable=arguments-differ
         processing.fix_seed(p)
         initial_batch_count = p.n_iter
         p.extra_generation_params['Loopback'] = final_denoising_strength
@@ -76,6 +79,10 @@ class Script(scripts_manager.Script):
                 if initial_seed is None:
                     initial_seed = processed.seed
                     initial_info = processed.info
+                if randomize_seed:
+                    p.seed = random.randrange(4294967294)
+                    p.all_seeds = [p.seed]
+                    log.info(f'Setting random seed {p.seed} for loopback iteration {i}')
                 p.seed = processed.seed + 1 # why?
                 p.denoising_strength = calculate_denoising_strength(i + 1)
                 last_image = processed.images[0]


### PR DESCRIPTION
## Description

This PR introduces an option, to randomize the seed of iterations, when using the loopback script in image2image.
The option consists of a new checkbox (boolean) and an adaption in the for loop that generates the images in the loopback.

Once activated, each image gets a new, random seed. The resulting images (if the option is activated) seems to follow the prompt better, and the results are "evolving", as it was the behavior in the implementation of Automatic1111.
If not activated, each iteration seems to get more and more crude (e.g. outlines are getting thicker)

## Notes

An issue (Enhancement) with a detailed description and example images was created: https://github.com/vladmandic/sdnext/issues/4234
The option is set to disabled by default, to keep the user experience of the loopback script consistent with the past releases.  

## Environment and Testing

The change was tested on a WIN10pro machine, with an Nvidia RTX 5060Ti GPU and 64GB of RAM and Python 3.12.3. The used checkpoint to test was Juggernaut XL XI. However, the old behavior (like increasing of outlines, instead of following the prompt) was experienced also with other checkpoints, like PonyXL, Illustrious or sdxl-turbo. The activated option always lead to (in my opinion) more appealing results.
Linting and checking was performed according to the contribution guide
