### PR TITLE
ROCm Adv Mgr: Only autoload if config file exists

### DIFF
--- a/scripts/rocm/rocm_mgr.py
+++ b/scripts/rocm/rocm_mgr.py
@@ -518,7 +518,7 @@ def info() -> dict:
 
 
 # Apply saved config to os.environ at import time (only when ROCm is present)
-if installer.torch_info.get('type', None) == 'rocm':
+if installer.torch_info.get('type', None) == 'rocm' and CONFIG.exists():
     try:
         apply_env()
     except Exception as _e:


### PR DESCRIPTION
This is the simplest way to prevent the environment variables from auto-loading all the time. I still have some concerns about the fact that fields auto-save/apply when changed, but that can be addressed later.