### PR TITLE
fix(openvino): always call move_model() on pipeline class change

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -1292,9 +1292,8 @@ def set_diffuser_pipe(pipe, new_pipe_type):
     fn = f'{sys._getframe(2).f_code.co_name}:{sys._getframe(1).f_code.co_name}' # pylint: disable=protected-access
     log.debug(f"Pipeline class change: original={cls} target={new_pipe.__class__.__name__} device={pipe.device} fn={fn}") # pylint: disable=protected-access
 
-    if shared.opts.diffusers_offload_mode == 'none':
-        move_model(new_pipe, pipe.device)
-    else:
+    move_model(new_pipe, pipe.device)
+    if shared.opts.diffusers_offload_mode != 'none':
         set_diffuser_offload(new_pipe, op='model')
 
     pipe = new_pipe


### PR DESCRIPTION
## Description

Fixes the SD.Next process crash that occurs the first time a pipeline class change fires (typically txt2img → img2img) when running with `--use-openvino` and any non-`none` `diffusers_offload_mode`.

In `set_diffuser_pipe()` (`modules/sd_models.py`), the previous code only called `move_model()` on the new pipeline when `diffusers_offload_mode == 'none'`. Otherwise it called `set_diffuser_offload(new_pipe, op='model')` *without* placing the pipeline first, which configures `enable_model_cpu_offload` hooks but leaves the pipeline without explicit device init. Empirically this leaves stale/conflicting accelerate hooks from the old pipeline in place; on Intel GPU + OpenVINO the OV runtime then throws `std::bad_array_new_length` from `infer_request.cpp:224` during the first inference and the process exits with SIGSEGV.

Fix: call `move_model()` unconditionally on the new pipeline, then layer offload on top when the offload mode is non-`none`.

Fixes #4828

## Notes

This is a 2-line behavior change (5 lines edited): the conditional structure becomes a sequential one. The `move_model()` call was previously *also* done in the `none` branch, so this PR is not adding new work for the `none` path — it's making the call universal so it applies before offload hook setup as well.

Risk on non-Intel hardware: the `move_model(pipe, pipe.device)` call is a no-op when the new pipeline already lives on the requested device, which is the common case for CUDA / DirectML / IPEX users since their pipelines initialize directly on GPU. Concretely:

- **CUDA/ROCm/DirectML/IPEX**: previous behavior left the pipeline placed by diffusers' default constructors (which target the CUDA-equivalent device when one is available). New behavior calls `move_model()` to confirm/repeat that placement, then applies offload as before. Functionally identical.
- **OpenVINO**: previous behavior skipped placement under offload modes; new behavior places before configuring offload, fixing the crash.

I have not observed any regression in the test matrix below.

## Environment and Testing

Tested on the following deployment for both pre-patch (crashes) and post-patch (works):

- **Hardware**: Intel Arc A310 LP 4GB on Ubuntu 24.04 (Linux), Dell OptiPlex 5050 / Q270 chipset
- **OpenVINO**: 2026.0.0 (`openvino/ubuntu24_dev:2026.0.0` base image)
- **SD.Next**: master @ `626197e` (2026-04-29)
- **Backend**: OpenVINO via `--use-openvino`
- **Offload mode**: `model` (the non-`none` case that triggers the bug)
- **Model**: SD 1.5 (juggernaut-reborn-sd15)

### Pre-patch (without the diff in this PR)

| Scenario | Result |
|---|---|
| txt2img (cold) | ✅ http 200 |
| txt2img → img2img (the bug) | ❌ `std::bad_array_new_length` → SIGSEGV |
| Pod restart count after first edit attempt | ≥1 (kubelet bounces it) |

### Post-patch (with the diff in this PR)

| Scenario | Result |
|---|---|
| txt2img (cold, 4 step warm-up) | ✅ http 200, ~43 s including OV cold compile |
| txt2img → img2img (the bug, 4 step) | ✅ http 200, real 512×512 PNG, ~10 s |
| img2img → txt2img (reverse direction) | ✅ http 200, ~3 s warm |
| img2img → img2img (warm) | ✅ http 200, ~3 s |
| txt2img → img2img → txt2img → img2img (alternation) | ✅ all four succeed |
| Pod uptime through the matrix | 12+ min, **0 restarts**, no segfault |
| End-to-end via Open WebUI `edit_image` over an OpenAI-compat shim → SD.Next img2img | ✅ http 200, real PNG returned |

A small standalone Python reproducer (`repro_pipeline_switch.py`) that asserts SD.Next survives the txt2img → img2img class change is included in the discussion of #4828; happy to attach it to this PR as a test fixture if useful.

I do not have access to NVIDIA, AMD, or DirectML hardware to test those backends directly. The change is structurally a no-op for them (`move_model` is idempotent when the pipeline is already on the target device) but if you'd like me to add an explicit branch that early-returns on non-OpenVINO backends, that's an easy follow-up.
