### PR TITLE
Feat/civitai embed preview meta

### DIFF
--- a/modules/civitai/download_civitai.py
+++ b/modules/civitai/download_civitai.py
@@ -345,13 +345,20 @@ download_manager = DownloadManager()
 
 # ---- Preview metadata helpers ----
 
+NOISE_META_KEYS = frozenset({'hashes', 'comfy', 'comfyui', 'workflow', 'extrametadata'})
+PASSTHROUGH_VALUE_LIMIT = 512  # chars; pass-through values longer than this are dropped
+
+
 def civitai_meta_to_parameters(meta: dict | None) -> str:
     """Convert Civitai version-image meta dict to sdnext parameters string.
 
     Output matches sdnext's standard `parameters` channel (`modules/image/save.py:65-72`):
     positive prompt on line one, optional `Negative prompt:` line two,
     comma-joined `Key: Value` pairs on line three. Round-trippable through
-    `modules.infotext.parse`.
+    `modules.infotext.parse`. Generator-specific noise keys (full ComfyUI
+    workflows, etc.) are dropped and any pass-through value exceeding
+    `PASSTHROUGH_VALUE_LIMIT` chars is omitted to keep the embedded chunk
+    compact.
     """
     if not meta or not isinstance(meta, dict):
         return ''
@@ -390,7 +397,7 @@ def civitai_meta_to_parameters(meta: dict | None) -> str:
     for k, v in meta.items():
         if k.lower() in consumed:
             continue
-        if k == 'hashes':
+        if k.lower() in NOISE_META_KEYS:
             continue
         if k in ('resources', 'civitaiResources'):
             try:
@@ -400,7 +407,10 @@ def civitai_meta_to_parameters(meta: dict | None) -> str:
             continue
         if v is None or v == '':
             continue
-        pairs.append(f'{k}: {quote(v)}')
+        quoted = quote(v)
+        if len(str(quoted)) > PASSTHROUGH_VALUE_LIMIT:
+            continue
+        pairs.append(f'{k}: {quoted}')
     lines = [str(prompt).strip()]
     if negative:
         lines.append(f'Negative prompt: {negative}')
@@ -409,18 +419,47 @@ def civitai_meta_to_parameters(meta: dict | None) -> str:
     return '\n'.join(lines)
 
 
+def fit_parameters_for_exif(parameters: str, limit: int = 30000) -> str:
+    """Trim parameters string to fit JPEG/WEBP EXIF UserComment.
+
+    JPEG's APP1 segment caps at 64KB; UserComment is UTF-16-LE encoded so
+    each char takes 2 bytes. A 30000-char limit keeps the encoded payload
+    around 60KB with headroom for piexif overhead. Drops the
+    `Civitai resources` field first (typical bloat source) and truncates as
+    last resort. PNG callers don't need this since `tEXt` chunks are
+    unbounded.
+    """
+    if len(parameters) <= limit:
+        return parameters
+    lines = parameters.split('\n')
+    if len(lines) >= 3:
+        parts = [p for p in lines[2].split(', ') if not p.startswith('Civitai resources:')]
+        lines[2] = ', '.join(parts)
+        parameters = '\n'.join(lines)
+        if len(parameters) <= limit:
+            return parameters
+    return parameters[:max(0, limit - 32)].rstrip() + '\n[truncated]'
+
+
 def embed_preview_parameters(preview_file: str, parameters: str) -> bool:
     """Embed parameters string into preview image at `preview_file`.
 
     PNG -> `tEXt` chunk with key `parameters`. JPEG/WEBP -> EXIF
-    `UserComment` via piexif. Other extensions: no-op. Returns success.
-    Embedding failure is swallowed and logged at debug — never raises.
+    `UserComment` via piexif. RGBA is converted to RGB before JPEG save.
+    Other extensions: no-op. Returns success.
+
+    Writes are atomic (temp file + os.replace). On success, any co-located
+    `<base>.thumb.jpg` is removed so the lazy thumb generator re-emits it
+    carrying the new params. Embed failures are swallowed and logged at
+    debug; the source file is removed only when PIL cannot read it back,
+    so the caller can re-download a fresh copy.
     """
     if not preview_file or not parameters:
         return False
     ext = os.path.splitext(preview_file)[1].lower()
     if ext not in ('.png', '.jpg', '.jpeg', '.webp'):
         return False
+    tmp_file = preview_file + '.embed.tmp'
     try:
         from PIL import Image
         img = Image.open(preview_file)
@@ -430,26 +469,88 @@ def embed_preview_parameters(preview_file: str, parameters: str) -> bool:
                 from PIL import PngImagePlugin
                 pnginfo = PngImagePlugin.PngInfo()
                 pnginfo.add_text('parameters', parameters)
-                img.save(preview_file, format='PNG', pnginfo=pnginfo)
+                img.save(tmp_file, format='PNG', pnginfo=pnginfo)
             else:
                 import piexif
                 import piexif.helper
-                exif_bytes = piexif.dump({'Exif': {piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(parameters, encoding='unicode')}})
-                fmt = 'JPEG' if ext in ('.jpg', '.jpeg') else 'WEBP'
-                img.save(preview_file, format=fmt, quality=95, exif=exif_bytes)
+                payload = fit_parameters_for_exif(parameters)
+                exif_bytes = piexif.dump({'Exif': {piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(payload, encoding='unicode')}})
+                if ext in ('.jpg', '.jpeg'):
+                    if img.mode != 'RGB':
+                        img = img.convert('RGB')
+                    img.save(tmp_file, format='JPEG', quality=95, exif=exif_bytes)
+                else:
+                    img.save(tmp_file, format='WEBP', quality=95, exif=exif_bytes)
         finally:
             img.close()
+        os.replace(tmp_file, preview_file)
+        thumb_base = os.path.splitext(preview_file)[0]
+        if thumb_base.endswith('.preview'):
+            thumb_base = thumb_base[:-len('.preview')]
+        thumb_file = thumb_base + '.thumb.jpg'
+        if os.path.exists(thumb_file):
+            try:
+                os.remove(thumb_file)
+                log.debug(f'CivitAI thumb invalidated: file="{thumb_file}"')
+            except Exception:
+                pass
         return True
     except Exception as e:
+        try:
+            if os.path.exists(tmp_file):
+                os.remove(tmp_file)
+        except Exception:
+            pass
+        try:
+            from PIL import Image as PILImage
+            with PILImage.open(preview_file) as probe:
+                probe.verify()
+        except Exception:
+            try:
+                os.remove(preview_file)
+                log.warning(f'CivitAI preview removing invalid: image={preview_file}')
+            except Exception:
+                pass
         log.debug(f'CivitAI preview embed failed: file="{preview_file}" {e}')
         return False
 
 
-def preview_has_parameters(preview_file: str) -> bool:
-    """Check whether `preview_file` already carries an embedded parameters string.
+def resolve_preview_file(item: dict) -> str | None:
+    """Resolve the actual on-disk preview file for a network item.
 
-    Mirrors the lookup `modules/image/metadata.py:read_info_from_image`
-    performs: PNG `image.info["parameters"]` or JPEG/WEBP EXIF `UserComment`.
+    `item['local_preview']` is the aspirational save path (e.g.
+    `<base>.<samples_format>`), not necessarily the existing file. This
+    helper extracts the real path from `item['preview']` URL (set by
+    `ExtraNetworksPage.link_preview`) and falls back to scanning common
+    extensions at the model base. Returns None when nothing on-disk
+    matches.
+    """
+    preview_url = item.get('preview') or ''
+    if preview_url and 'missing.png' not in preview_url:
+        try:
+            import urllib.parse
+            parsed = urllib.parse.urlparse(preview_url)
+            fn = urllib.parse.parse_qs(parsed.query).get('filename', [None])[0]
+            if fn:
+                fn = urllib.parse.unquote(fn)
+                if os.path.isfile(fn):
+                    return fn
+        except Exception:
+            pass
+    filename = item.get('filename')
+    if not filename:
+        return None
+    return find_ui_preview_file(filename)
+
+
+def preview_has_parameters(preview_file: str) -> bool:
+    """Check whether `preview_file` carries a non-empty embedded parameters string.
+
+    Mirrors `modules/image/metadata.py:read_info_from_image`: PNG
+    `image.info["parameters"]` or JPEG/WEBP EXIF `UserComment`. EXIF
+    UserComment is decoded via piexif.helper to verify a non-empty body;
+    the 8-byte `b"UNICODE\\x00"` header is present in any UserComment
+    even when its body is empty.
     """
     if not preview_file or not os.path.exists(preview_file):
         return False
@@ -458,17 +559,24 @@ def preview_has_parameters(preview_file: str) -> bool:
         img = Image.open(preview_file)
         try:
             info = img.info or {}
-            if info.get('parameters'):
-                return True
-            if info.get('UserComment'):
-                return True
+            for key in ('parameters', 'UserComment'):
+                value = info.get(key)
+                if value and str(value).strip():
+                    return True
             exif = info.get('exif')
             if exif:
                 import piexif
+                import piexif.helper
                 try:
                     parsed = piexif.load(exif)
-                    if parsed.get('Exif', {}).get(piexif.ExifIFD.UserComment):
-                        return True
+                    raw = parsed.get('Exif', {}).get(piexif.ExifIFD.UserComment)
+                    if raw:
+                        try:
+                            decoded = piexif.helper.UserComment.load(raw)
+                        except Exception:
+                            decoded = ''
+                        if decoded and decoded.strip():
+                            return True
                 except Exception:
                     pass
         finally:
@@ -478,20 +586,52 @@ def preview_has_parameters(preview_file: str) -> bool:
     return False
 
 
+VIDEO_PREVIEW_EXTENSIONS = ('.mp4', '.webm')
+UI_PREVIEW_EXTS = ('jpg', 'jpeg', 'png', 'webp')
+UI_PREVIEW_MIDS = ('.thumb.', '.', '.preview.')
+
+
+def find_ui_preview_file(model_path: str) -> str | None:
+    """Return the preview file the modernUI surfaces for `model_path`.
+
+    Iteration mirrors `ExtraNetworksPage.find_preview` at
+    `modules/ui_extra_networks.py:488` so that backfill embeds into the
+    same file the UI reads.
+    """
+    base = os.path.splitext(model_path)[0]
+    for ext in UI_PREVIEW_EXTS:
+        for mid in UI_PREVIEW_MIDS:
+            candidate = f'{base}{mid}{ext}'
+            if os.path.isfile(candidate):
+                return candidate
+    return None
+
+
 def backfill_preview_parameters(model_path: str, preview_url: str, meta: dict | None) -> bool:
     """Embed Civitai meta into an existing preview file when it lacks parameters.
 
     Used by the rescan path to retroactively populate preview metadata
-    without re-downloading bytes. Returns True only if a new chunk was
-    written; False for no-op (file missing, no meta, already populated,
-    embed failed).
+    without re-downloading bytes. The embed target is the file
+    `find_ui_preview_file` surfaces, which matches what the modernUI
+    displays. For video previews the embed target is the extracted
+    `<base>.thumb.jpg` frame instead of the unembeddable video file.
+    Returns True only if a new chunk was written; False for no-op (file
+    missing, no meta, already populated, embed failed).
     """
     if not meta or not model_path or not preview_url:
         return False
-    ext = os.path.splitext(preview_url)[1]
-    preview_file = os.path.splitext(model_path)[0] + ext
-    if not os.path.exists(preview_file):
-        return False
+    ext = os.path.splitext(preview_url)[1].lower()
+    base = os.path.splitext(model_path)[0]
+    if ext in VIDEO_PREVIEW_EXTENSIONS:
+        if not os.path.exists(base + ext):
+            return False
+        preview_file = base + '.thumb.jpg'
+        if not os.path.exists(preview_file):
+            return False
+    else:
+        preview_file = find_ui_preview_file(model_path)
+        if not preview_file:
+            return False
     if preview_has_parameters(preview_file):
         return False
     parameters = civitai_meta_to_parameters(meta)
@@ -529,7 +669,7 @@ def download_civit_preview(model_path: str, preview_url: str, meta: dict | None 
         return 500, '', ''
     ext = os.path.splitext(preview_url)[1]
     preview_file = os.path.splitext(model_path)[0] + ext
-    is_video = preview_file.lower().endswith('.mp4')
+    is_video = preview_file.lower().endswith(VIDEO_PREVIEW_EXTENSIONS)
     is_json = preview_file.lower().endswith('.json')
     if is_json:
         log.warning(f'CivitAI download: url="{preview_url}" skip json')
@@ -552,6 +692,15 @@ def download_civit_preview(model_path: str, preview_url: str, meta: dict | None 
         if is_video:
             from modules.civitai.video_helper import save_video_frame
             save_video_frame(preview_file)
+            if meta:
+                thumb_file = os.path.splitext(preview_file)[0] + '.thumb.jpg'
+                if os.path.exists(thumb_file):
+                    try:
+                        parameters = civitai_meta_to_parameters(meta)
+                        if parameters and embed_preview_parameters(thumb_file, parameters):
+                            log.debug(f'CivitAI preview embed: file="{thumb_file}"')
+                    except Exception as e:
+                        log.debug(f'CivitAI preview embed skipped: file="{thumb_file}" {e}')
         else:
             from PIL import Image
             img = Image.open(preview_file)

--- a/modules/civitai/download_civitai.py
+++ b/modules/civitai/download_civitai.py
@@ -327,6 +327,9 @@ class DownloadManager:
                         if code == 200:
                             log.info(f'CivitAI preview saved: id={item.id}')
                             break
+                        if code == 304 and backfill_preview_parameters(final_file, img.url, img.meta):
+                            log.info(f'CivitAI preview backfilled: id={item.id}')
+                            break
         except Exception as e:
             log.warning(f'CivitAI preview fetch failed: id={item.id} {e}')
 
@@ -440,6 +443,64 @@ def embed_preview_parameters(preview_file: str, parameters: str) -> bool:
     except Exception as e:
         log.debug(f'CivitAI preview embed failed: file="{preview_file}" {e}')
         return False
+
+
+def preview_has_parameters(preview_file: str) -> bool:
+    """Check whether `preview_file` already carries an embedded parameters string.
+
+    Mirrors the lookup `modules/image/metadata.py:read_info_from_image`
+    performs: PNG `image.info["parameters"]` or JPEG/WEBP EXIF `UserComment`.
+    """
+    if not preview_file or not os.path.exists(preview_file):
+        return False
+    try:
+        from PIL import Image
+        img = Image.open(preview_file)
+        try:
+            info = img.info or {}
+            if info.get('parameters'):
+                return True
+            if info.get('UserComment'):
+                return True
+            exif = info.get('exif')
+            if exif:
+                import piexif
+                try:
+                    parsed = piexif.load(exif)
+                    if parsed.get('Exif', {}).get(piexif.ExifIFD.UserComment):
+                        return True
+                except Exception:
+                    pass
+        finally:
+            img.close()
+    except Exception:
+        pass
+    return False
+
+
+def backfill_preview_parameters(model_path: str, preview_url: str, meta: dict | None) -> bool:
+    """Embed Civitai meta into an existing preview file when it lacks parameters.
+
+    Used by the rescan path to retroactively populate preview metadata
+    without re-downloading bytes. Returns True only if a new chunk was
+    written; False for no-op (file missing, no meta, already populated,
+    embed failed).
+    """
+    if not meta or not model_path or not preview_url:
+        return False
+    ext = os.path.splitext(preview_url)[1]
+    preview_file = os.path.splitext(model_path)[0] + ext
+    if not os.path.exists(preview_file):
+        return False
+    if preview_has_parameters(preview_file):
+        return False
+    parameters = civitai_meta_to_parameters(meta)
+    if not parameters:
+        return False
+    if embed_preview_parameters(preview_file, parameters):
+        log.info(f'CivitAI preview backfill: file="{preview_file}"')
+        return True
+    return False
 
 
 # ---- Legacy compatibility functions ----

--- a/modules/civitai/download_civitai.py
+++ b/modules/civitai/download_civitai.py
@@ -323,7 +323,7 @@ class DownloadManager:
             if version and version.images:
                 for img in version.images:
                     if img.url:
-                        code, _size, _note = download_civit_preview(final_file, img.url)
+                        code, _size, _note = download_civit_preview(final_file, img.url, meta=img.meta)
                         if code == 200:
                             log.info(f'CivitAI preview saved: id={item.id}')
                             break
@@ -338,6 +338,108 @@ class DownloadManager:
 
 
 download_manager = DownloadManager()
+
+
+# ---- Preview metadata helpers ----
+
+def civitai_meta_to_parameters(meta: dict | None) -> str:
+    """Convert Civitai version-image meta dict to sdnext parameters string.
+
+    Output matches sdnext's standard `parameters` channel (`modules/image/save.py:65-72`):
+    positive prompt on line one, optional `Negative prompt:` line two,
+    comma-joined `Key: Value` pairs on line three. Round-trippable through
+    `modules.infotext.parse`.
+    """
+    if not meta or not isinstance(meta, dict):
+        return ''
+    import json
+    from modules.infotext import quote
+    lower = {k.lower(): (k, v) for k, v in meta.items()}
+
+    def lookup(*keys):
+        for k in keys:
+            if k.lower() in lower:
+                return lower[k.lower()][1]
+        return None
+
+    prompt = lookup('prompt') or ''
+    negative = lookup('negativePrompt', 'negative_prompt', 'Negative prompt') or ''
+    pairs = []
+    mapping = [
+        (('steps',), 'Steps'),
+        (('sampler',), 'Sampler'),
+        (('cfgScale', 'cfg_scale', 'CFG scale'), 'CFG scale'),
+        (('seed',), 'Seed'),
+        (('Size',), 'Size'),
+        (('Model',), 'Model'),
+        (('Model hash', 'modelHash'), 'Model hash'),
+        (('clipSkip', 'clip_skip', 'Clip skip'), 'Clip skip'),
+        (('denoisingStrength', 'Denoising strength'), 'Denoising strength'),
+    ]
+    consumed = {'prompt', 'negativeprompt', 'negative_prompt'}
+    for src_keys, out_key in mapping:
+        v = lookup(*src_keys)
+        if v is None or v == '':
+            continue
+        pairs.append(f'{out_key}: {quote(v)}')
+        for k in src_keys:
+            consumed.add(k.lower())
+    for k, v in meta.items():
+        if k.lower() in consumed:
+            continue
+        if k == 'hashes':
+            continue
+        if k in ('resources', 'civitaiResources'):
+            try:
+                pairs.append(f'Civitai resources: {quote(json.dumps(v, separators=(",", ":")))}')
+            except Exception:
+                pass
+            continue
+        if v is None or v == '':
+            continue
+        pairs.append(f'{k}: {quote(v)}')
+    lines = [str(prompt).strip()]
+    if negative:
+        lines.append(f'Negative prompt: {negative}')
+    if pairs:
+        lines.append(', '.join(pairs))
+    return '\n'.join(lines)
+
+
+def embed_preview_parameters(preview_file: str, parameters: str) -> bool:
+    """Embed parameters string into preview image at `preview_file`.
+
+    PNG -> `tEXt` chunk with key `parameters`. JPEG/WEBP -> EXIF
+    `UserComment` via piexif. Other extensions: no-op. Returns success.
+    Embedding failure is swallowed and logged at debug — never raises.
+    """
+    if not preview_file or not parameters:
+        return False
+    ext = os.path.splitext(preview_file)[1].lower()
+    if ext not in ('.png', '.jpg', '.jpeg', '.webp'):
+        return False
+    try:
+        from PIL import Image
+        img = Image.open(preview_file)
+        img.load()
+        try:
+            if ext == '.png':
+                from PIL import PngImagePlugin
+                pnginfo = PngImagePlugin.PngInfo()
+                pnginfo.add_text('parameters', parameters)
+                img.save(preview_file, format='PNG', pnginfo=pnginfo)
+            else:
+                import piexif
+                import piexif.helper
+                exif_bytes = piexif.dump({'Exif': {piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(parameters, encoding='unicode')}})
+                fmt = 'JPEG' if ext in ('.jpg', '.jpeg') else 'WEBP'
+                img.save(preview_file, format=fmt, quality=95, exif=exif_bytes)
+        finally:
+            img.close()
+        return True
+    except Exception as e:
+        log.debug(f'CivitAI preview embed failed: file="{preview_file}" {e}')
+        return False
 
 
 # ---- Legacy compatibility functions ----
@@ -361,7 +463,7 @@ def download_civit_meta(model_path: str, model_id):
     return r.status_code, '', ''
 
 
-def download_civit_preview(model_path: str, preview_url: str):
+def download_civit_preview(model_path: str, preview_url: str, meta: dict | None = None):
     if model_path is None:
         return 500, '', ''
     ext = os.path.splitext(preview_url)[1]
@@ -394,6 +496,13 @@ def download_civit_preview(model_path: str, preview_url: str):
             img = Image.open(preview_file)
             log.info(f'CivitAI download: url={preview_url} file="{preview_file}" size={total_size} image={img.size}')
             img.close()
+            if meta:
+                try:
+                    parameters = civitai_meta_to_parameters(meta)
+                    if parameters and embed_preview_parameters(preview_file, parameters):
+                        log.debug(f'CivitAI preview embed: file="{preview_file}"')
+                except Exception as e:
+                    log.debug(f'CivitAI preview embed skipped: file="{preview_file}" {e}')
     except Exception as e:
         log.error(f'CivitAI download error: url={preview_url} file="{preview_file}" written={written} {e}')
         shared.state.end(jobid)

--- a/modules/civitai/metadata_civitai.py
+++ b/modules/civitai/metadata_civitai.py
@@ -104,7 +104,7 @@ def civit_update_metadata(raw: bool = False):
 
 
 def atomic_civit_search_metadata(item, results):
-    from modules.civitai.download_civitai import download_civit_preview, download_civit_meta
+    from modules.civitai.download_civitai import download_civit_preview, download_civit_meta, backfill_preview_parameters
     if item is None:
         return
     try:
@@ -141,6 +141,10 @@ def atomic_civit_search_metadata(item, results):
                             results.append({**result, 'code': code, 'size': size, 'note': note, 'type': 'preview'})
                             found = True
                             break
+                        if code == 304 and backfill_preview_parameters(item['filename'], img.url, img.meta):
+                            results.append({**result, 'code': 200, 'size': '', 'note': 'metadata embedded', 'type': 'preview'})
+                            found = True
+                            break
             else:
                 result['code'] = 404
             time.sleep(0.25)  # rate limiting
@@ -160,6 +164,10 @@ def atomic_civit_search_metadata(item, results):
                         code, size, note = download_civit_preview(item['filename'], img.url, meta=img.meta)
                         if code == 200:
                             results.append({**result, 'code': code, 'size': size, 'note': note, 'type': 'preview'})
+                            found = True
+                            break
+                        if code == 304 and backfill_preview_parameters(item['filename'], img.url, img.meta):
+                            results.append({**result, 'code': 200, 'size': '', 'note': 'metadata embedded', 'type': 'preview'})
                             found = True
                             break
             else:

--- a/modules/civitai/metadata_civitai.py
+++ b/modules/civitai/metadata_civitai.py
@@ -136,7 +136,7 @@ def atomic_civit_search_metadata(item, results):
                 results.append(dict(result))
                 for img in version.images:
                     if img.url:
-                        code, size, note = download_civit_preview(item['filename'], img.url)
+                        code, size, note = download_civit_preview(item['filename'], img.url, meta=img.meta)
                         if code == 200:
                             results.append({**result, 'code': code, 'size': size, 'note': note, 'type': 'preview'})
                             found = True
@@ -157,7 +157,7 @@ def atomic_civit_search_metadata(item, results):
                 results.append(dict(result))
                 for img in version.images:
                     if img.url:
-                        code, size, note = download_civit_preview(item['filename'], img.url)
+                        code, size, note = download_civit_preview(item['filename'], img.url, meta=img.meta)
                         if code == 200:
                             results.append({**result, 'code': code, 'size': size, 'note': note, 'type': 'preview'})
                             found = True

--- a/modules/civitai/metadata_civitai.py
+++ b/modules/civitai/metadata_civitai.py
@@ -104,7 +104,7 @@ def civit_update_metadata(raw: bool = False):
 
 
 def atomic_civit_search_metadata(item, results):
-    from modules.civitai.download_civitai import download_civit_preview, download_civit_meta, backfill_preview_parameters
+    from modules.civitai.download_civitai import download_civit_preview, download_civit_meta, backfill_preview_parameters, preview_has_parameters, resolve_preview_file
     if item is None:
         return
     try:
@@ -112,7 +112,12 @@ def atomic_civit_search_metadata(item, results):
     except Exception:
         return
     has_meta = os.path.isfile(meta) and os.stat(meta).st_size > 0
-    if ('missing.png' in item['preview'] or not has_meta) and os.path.isfile(item['filename']):
+    needs_backfill = False
+    if has_meta and 'missing.png' not in item.get('preview', ''):
+        actual_preview = resolve_preview_file(item)
+        if actual_preview and not preview_has_parameters(actual_preview):
+            needs_backfill = True
+    if ('missing.png' in item['preview'] or not has_meta or needs_backfill) and os.path.isfile(item['filename']):
         sha = item.get('hash', None)
         found = False
         result = {

--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -206,19 +206,29 @@ class ExtraNetworksPage:
     def get_exif(self, image: Image.Image):
         import piexif
         import piexif.helper
+        parameters = ''
         try:
-            exifinfo = image.getexif()
-            if exifinfo is not None and len(exifinfo) > 0:
-                return piexif.dump({ "Exif": { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(exifinfo, encoding="unicode") } })
+            info = image.info or {}
+            for key in ('parameters', 'UserComment'):
+                value = info.get(key)
+                if value and str(value).strip():
+                    parameters = str(value)
+                    break
         except Exception:
             pass
-        try:
-            exifinfo = image.info.get('parameters', None)
-            if exifinfo is not None and len(exifinfo) > 0:
-                return piexif.dump({ "Exif": { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(exifinfo, encoding="unicode") } })
-        except Exception:
-            pass
-        return piexif.dump({ "Exif": { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump('', encoding="unicode") } })
+        if not parameters:
+            try:
+                exif_bytes = (image.info or {}).get('exif')
+                if exif_bytes:
+                    parsed = piexif.load(exif_bytes)
+                    raw = parsed.get('Exif', {}).get(piexif.ExifIFD.UserComment)
+                    if raw:
+                        decoded = piexif.helper.UserComment.load(raw)
+                        if decoded and decoded.strip():
+                            parameters = decoded
+            except Exception:
+                pass
+        return piexif.dump({ "Exif": { piexif.ExifIFD.UserComment: piexif.helper.UserComment.dump(parameters, encoding="unicode") } })
 
     def create_thumb(self):
         debug(f'EN create-thumb: {self.name}')


### PR DESCRIPTION
## Description

Embeds Civitai version API's `images[].meta` into the saved preview at download time so the Modern UI "Preview metadata" tab populates for Civitai-downloaded networks. Existing libraries are covered via the "Search missing" rescan.

This function needs so much handling; it's like a baby trying to stick a fork into the electrical outlet. I caught everything I could think of, doesn't seem like anything is failing on the 7500 adaptors I have on hand, so it gotta count for something.

## Notes

- `civitai_meta_to_parameters` formats the meta dict into sdnext's standard `parameters` shape (PNG `tEXt`; EXIF `UserComment` via `piexif` for `.jpg`/`.jpeg`/`.webp`) so `read_info_from_image` picks it up.
- Generator-specific bloat dropped (`comfy`, `comfyui`, `workflow`, `extraMetadata`); pass-through values cap at 512 chars.
- JPEG/WEBP go through `fit_parameters_for_exif` to stay under the 64KB APP1 limit (drops `Civitai resources` first, truncates as last resort).
- `embed_preview_parameters` writes via temp + `os.replace`, converts RGBA to RGB before JPEG save, removes unreadable sources, and invalidates any co-located `.thumb.jpg`.
- For `.mp4`/`.webm` previews the embed target is the `.thumb.jpg` extracted by `save_video_frame` rather than the video file.
- Backfill rides the existing `civit_search_metadata` rescan. The gate in `atomic_civit_search_metadata` gained a `needs_backfill` predicate that fires when the on-disk preview lacks a non-empty `UserComment` (the canonical 8-byte `b"UNICODE\x00"` header alone is treated as empty).
- The `304` branch calls `backfill_preview_parameters`, which targets whatever `find_ui_preview_file` surfaces. That helper mirrors `find_preview`'s extension-outer / mid-inner iteration so multi-variant cases (e.g. `<base>.jpg` and `<base>.jpeg` coexisting) resolve to the file used for preview.
- `ui_extra_networks.py:get_exif` is touched (one caller, `create_thumb`) so JPEG/WEBP EXIF `UserComment` propagates into regenerated thumbs.