### PR TITLE
Feat/flux2 native adapters

### DIFF
--- a/modules/lora/extra_networks_lora.py
+++ b/modules/lora/extra_networks_lora.py
@@ -218,11 +218,11 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
         requested = self.signature(names, te_multipliers, unet_multipliers)
         reason = ''
 
-        load_method = lora_overrides.get_method()
+        load_method, load_reason = lora_overrides.get_method()
         if debug:
             import sys
             fn = f'{sys._getframe(2).f_code.co_name}:{sys._getframe(1).f_code.co_name}' # pylint: disable=protected-access
-            debug_log(f'Network load: type=LoRA include={include} exclude={exclude} method={load_method} requested={requested} fn={fn}')
+            debug_log(f'Network load: type=LoRA include={include} exclude={exclude} method={load_method} reason={load_reason} requested={requested} fn={fn}')
 
         if load_method == 'diffusers':
             has_changed, reason = self.changed(requested)
@@ -255,7 +255,7 @@ class ExtraNetworkLora(extra_networks.ExtraNetwork):
             prompt(p)
             if has_changed and len(include) == 0: # print only once
                 actual_method = 'native' if any(len(n.modules) > 0 for n in l.loaded_networks) else load_method
-                log.info(f'Network load: type=LoRA networks={[n.name for n in l.loaded_networks]} load={load_method} method={actual_method} mode={"fuse" if shared.opts.lora_fuse_native else "backup"} te={te_multipliers} unet={unet_multipliers} time={l.timer.summary} reason={reason}')
+                log.info(f'Network load: type=LoRA networks={[n.name for n in l.loaded_networks]} load={load_method}({load_reason}) method={actual_method} mode={"fuse" if shared.opts.lora_fuse_native else "backup"} te={te_multipliers} unet={unet_multipliers} time={l.timer.summary} reason={reason}')
 
     def deactivate(self, p, force=False):
         if len(lora_diffusers.diffuser_loaded) > 0 and (shared.opts.lora_force_reload or force):

--- a/modules/lora/lora_apply.py
+++ b/modules/lora/lora_apply.py
@@ -112,7 +112,7 @@ def network_calc_weights(self: torch.nn.Conv2d | torch.nn.Linear | torch.nn.Grou
                 else:
                     batch_updown = updown.to(devices.device)
             if ex_bias is not None:
-                if batch_ex_bias:
+                if batch_ex_bias is not None:
                     batch_ex_bias += ex_bias.to(batch_ex_bias.device)
                 else:
                     batch_ex_bias = ex_bias.to(devices.device)

--- a/modules/lora/lora_diffusers.py
+++ b/modules/lora/lora_diffusers.py
@@ -50,11 +50,11 @@ def load_per_module(sd_model: diffusers.DiffusionPipeline, filename: str, adapte
     return adapter_name
 
 
-def load_diffusers(name: str, network_on_disk: network.NetworkOnDisk, lora_scale:float=shared.opts.extra_networks_default_multiplier, lora_module=None) -> network.Network | None:
+def load_diffusers(name: str, network_on_disk: network.NetworkOnDisk, lora_scale:float=shared.opts.extra_networks_default_multiplier, lora_module=None, reason: str = '') -> network.Network | None:
     t0 = time.time()
     name = name.replace(".", "_")
     sd_model: diffusers.DiffusionPipeline = getattr(shared.sd_model, "pipe", shared.sd_model)
-    log.debug(f'Network load: type=LoRA name="{name}" file="{network_on_disk.filename}" detected={network_on_disk.sd_version} method=diffusers scale={lora_scale} fuse={shared.opts.lora_fuse_native}:{shared.opts.lora_fuse_diffusers}')
+    log.debug(f'Network load: type=LoRA name="{name}" file="{network_on_disk.filename}" detected={network_on_disk.sd_version} method=diffusers reason={reason or "unknown"} scale={lora_scale} fuse={shared.opts.lora_fuse_native}:{shared.opts.lora_fuse_diffusers}')
     if not hasattr(sd_model, 'load_lora_weights'):
         log.error(f'Network load: type=LoRA class={sd_model.__class__} does not implement load lora')
         return None

--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -103,25 +103,7 @@ def load_safetensors(name, network_on_disk: network.NetworkOnDisk) -> network.Ne
         return chroma_net
     if shared.sd_model_type == 'f2':
         from pipelines.flux import flux2_lora
-        lora_scale = shared.opts.extra_networks_default_multiplier
-        f2_net = None
-        for try_fn in (
-            flux2_lora.try_load_lora,
-            flux2_lora.try_load_lokr,
-            flux2_lora.try_load_loha,
-            flux2_lora.try_load_oft,
-            flux2_lora.try_load_ia3,
-            flux2_lora.try_load_glora,
-            flux2_lora.try_load_norm,
-            flux2_lora.try_load_full,
-        ):
-            sub = try_fn(name, network_on_disk, lora_scale)
-            if sub is None:
-                continue
-            if f2_net is None:
-                f2_net = sub
-            else:
-                f2_net.modules.update(sub.modules)
+        f2_net = flux2_lora.try_load(name, network_on_disk, shared.opts.extra_networks_default_multiplier)
         if f2_net is not None:
             lora_cache[name] = f2_net
         return f2_net

--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -101,6 +101,30 @@ def load_safetensors(name, network_on_disk: network.NetworkOnDisk) -> network.Ne
         if chroma_net is not None:
             lora_cache[name] = chroma_net
         return chroma_net
+    if shared.sd_model_type == 'f2':
+        from pipelines.flux import flux2_lora
+        lora_scale = shared.opts.extra_networks_default_multiplier
+        f2_net = None
+        for try_fn in (
+            flux2_lora.try_load_lora,
+            flux2_lora.try_load_lokr,
+            flux2_lora.try_load_loha,
+            flux2_lora.try_load_oft,
+            flux2_lora.try_load_ia3,
+            flux2_lora.try_load_glora,
+            flux2_lora.try_load_norm,
+            flux2_lora.try_load_full,
+        ):
+            sub = try_fn(name, network_on_disk, lora_scale)
+            if sub is None:
+                continue
+            if f2_net is None:
+                f2_net = sub
+            else:
+                f2_net.modules.update(sub.modules)
+        if f2_net is not None:
+            lora_cache[name] = f2_net
+        return f2_net
     net = network.Network(name, network_on_disk)
     net.mtime = os.path.getmtime(network_on_disk.filename)
     state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
@@ -309,13 +333,7 @@ def network_load(names, te_multipliers=None, unet_multipliers=None, dyn_dims=Non
                     shared.compiled_model_state.lora_model.append(f"{name}:{lora_scale}")
                 lora_method = lora_overrides.get_method(shorthash)
                 if lora_method == 'diffusers':
-                    if shared.sd_model_type == 'f2':
-                        from pipelines.flux import flux2_lora
-                        net = flux2_lora.try_load_lokr(name, network_on_disk, lora_scale)
-                        if net is None and not shared.opts.lora_force_diffusers:
-                            net = flux2_lora.try_load_lora(name, network_on_disk, lora_scale)
-                    if net is None:
-                        net = lora_diffusers.load_diffusers(name, network_on_disk, lora_scale, lora_module)
+                    net = lora_diffusers.load_diffusers(name, network_on_disk, lora_scale, lora_module)
                 elif lora_method == 'nunchaku':
                     pass # handled directly from extra_networks_lora.load_nunchaku
                 else:

--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -331,9 +331,9 @@ def network_load(names, te_multipliers=None, unet_multipliers=None, dyn_dims=Non
                 lora_module = lora_modules[i] if lora_modules and len(lora_modules) > i else None
                 if recompile_model and shared.compiled_model_state is not None:
                     shared.compiled_model_state.lora_model.append(f"{name}:{lora_scale}")
-                lora_method = lora_overrides.get_method(shorthash)
+                lora_method, lora_method_reason = lora_overrides.get_method(shorthash)
                 if lora_method == 'diffusers':
-                    net = lora_diffusers.load_diffusers(name, network_on_disk, lora_scale, lora_module)
+                    net = lora_diffusers.load_diffusers(name, network_on_disk, lora_scale, lora_module, reason=lora_method_reason)
                 elif lora_method == 'nunchaku':
                     pass # handled directly from extra_networks_lora.load_nunchaku
                 else:

--- a/modules/lora/lora_overrides.py
+++ b/modules/lora/lora_overrides.py
@@ -44,18 +44,36 @@ fuse_ignore = [
 
 
 def get_method(shorthash=''):
-    use_diffusers = shared.opts.lora_force_diffusers or (shared.sd_model.__class__.__name__ in force_classes_diffusers) or (shared.sd_model_type not in allow_native)
-    if len(shorthash) > 4:
-        use_diffusers = use_diffusers or any(x.startswith(shorthash) for x in force_hashes_diffusers)
+    """Return ``(method, reason)`` for the active LoRA loading strategy.
+
+    ``method`` is one of ``'native'``, ``'diffusers'``, ``'nunchaku'``.
+    ``reason`` is a short identifier indicating which condition triggered the
+    chosen method, useful for distinguishing user-opt-in from automatic
+    fallback in logs. Reasons:
+
+    - ``'nunchaku-transformer'`` / ``'nunchaku-unet'``: a Nunchaku-quantized
+      component is loaded.
+    - ``'opt-in'``: ``shared.opts.lora_force_diffusers`` is on (settings).
+    - ``'class-forced'``: pipeline class is in ``force_classes_diffusers``.
+    - ``'arch-unsupported'``: ``sd_model_type`` is not in ``allow_native``.
+    - ``'hash-forced'``: file hash is in ``force_hashes_diffusers``.
+    - ``'default'``: native path is the active and unforced choice.
+    """
     nunchaku_dit = hasattr(shared.sd_model, 'transformer') and 'Nunchaku' in shared.sd_model.transformer.__class__.__name__
     nunchaku_unet = hasattr(shared.sd_model, 'unet') and 'Nunchaku' in shared.sd_model.unet.__class__.__name__
-    use_nunchaku = nunchaku_dit or nunchaku_unet
-    if use_nunchaku:
-        return 'nunchaku'
-    elif use_diffusers:
-        return 'diffusers'
-    else:
-        return 'native'
+    if nunchaku_dit:
+        return 'nunchaku', 'nunchaku-transformer'
+    if nunchaku_unet:
+        return 'nunchaku', 'nunchaku-unet'
+    if shared.opts.lora_force_diffusers:
+        return 'diffusers', 'opt-in'
+    if shared.sd_model.__class__.__name__ in force_classes_diffusers:
+        return 'diffusers', 'class-forced'
+    if shared.sd_model_type not in allow_native:
+        return 'diffusers', 'arch-unsupported'
+    if len(shorthash) > 4 and any(x.startswith(shorthash) for x in force_hashes_diffusers):
+        return 'diffusers', 'hash-forced'
+    return 'native', 'default'
 
 
 def disable_fuse():

--- a/modules/lora/lora_overrides.py
+++ b/modules/lora/lora_overrides.py
@@ -26,6 +26,7 @@ allow_native = [
     'sdxl',
     'sd3',
     'f1',
+    'f2',
     'chroma',
     'zimage',
     'anima',

--- a/modules/lora/network_boft.py
+++ b/modules/lora/network_boft.py
@@ -1,0 +1,119 @@
+"""BOFT (Butterfly-OFT) — cascade of butterfly orthogonal factors.
+
+Saves with the same ``oft_blocks`` key as OFT but as a 4-D tensor
+``(boft_m, block_num, block_size, block_size)``. The caller in
+:func:`pipelines.flux.flux2_lora.try_load_oft` discriminates BOFT from
+OFT by ``oft_blocks.ndim == 4``. Math ported from
+``KohakuBlueleaf/LyCORIS/lycoris/modules/boft.py``.
+"""
+
+import torch
+import modules.lora.network as network
+
+
+class ModuleTypeBOFT(network.ModuleType):
+    def create_module(self, net: network.Network, weights: network.NetworkWeights):
+        ob = weights.w.get("oft_blocks")
+        if ob is not None and ob.ndim == 4:
+            return NetworkModuleBOFT(net, weights)
+        return None
+
+
+class NetworkModuleBOFT(network.NetworkModule):  # pylint: disable=abstract-method
+    """Butterfly-OFT module: cascade of orthogonal factors.
+
+    Constructor signature mirrors :class:`NetworkModuleOFT` so it slots into
+    the same ``finalize_updown`` pipeline. The ``boft_m``/``block_num``/
+    ``block_size`` triple is read from the saved tensor's shape rather than
+    re-derived via :func:`butterfly_factor`, which keeps loading deterministic
+    even if the upstream factorization heuristic changes.
+    """
+
+    def __init__(self, net: network.Network, weights: network.NetworkWeights):
+        super().__init__(net, weights)
+        self.org_module: list[torch.nn.Module] = [self.sd_module]
+        self.scale = 1.0
+
+        # 4-D oft_blocks: (boft_m, block_num, block_size, block_size)
+        self.oft_blocks = weights.w["oft_blocks"]
+        self.alpha = weights.w["alpha"]
+        self.rescale = weights.w.get("rescale")
+        self.boft_m = self.oft_blocks.shape[0]
+        self.block_num = self.oft_blocks.shape[1]
+        self.block_size = self.oft_blocks.shape[2]
+        self.boft_b = self.block_size
+
+        # Resolve out_dim from the host module — matches NetworkModuleOFT's
+        # discrimination so Linear/Conv2d hosts both work.
+        is_linear = type(self.sd_module) in [torch.nn.Linear, torch.nn.modules.linear.NonDynamicallyQuantizableLinear]
+        is_conv = type(self.sd_module) in [torch.nn.Conv2d]
+        if is_linear:
+            self.out_dim = self.sd_module.out_features
+        elif is_conv:
+            self.out_dim = self.sd_module.out_channels
+        else:
+            self.out_dim = self.block_num * self.block_size
+
+        # constraint scales with out_dim per LyCORIS BOFT init
+        self.constraint = float(self.alpha) * self.out_dim if self.alpha is not None else 0.0
+
+    def _get_r(self, target: torch.Tensor):
+        """Compute the per-stage Cayley rotations.
+
+        Returns a tensor of shape ``(boft_m, block_num, block_size, block_size)``
+        where each ``r[i]`` is a stack of ``block_num`` orthogonal matrices
+        derived from the i-th butterfly factor via Cayley's parameterization
+        of SO(n): ``R = (I + Q)(I - Q)^-1`` for skew-symmetric ``Q``.
+        """
+        eye = torch.eye(self.block_size, device=target.device, dtype=target.dtype)
+        oft_blocks = self.oft_blocks.to(target.device, dtype=target.dtype)
+        q = oft_blocks - oft_blocks.transpose(-1, -2)
+        if self.constraint > 0:
+            q_norm = torch.norm(q) + 1e-8
+            if q_norm > self.constraint:
+                q = q * self.constraint / q_norm
+        # Inverse needs fp32 to be numerically well-behaved across all dtypes;
+        # cast back to target dtype after.
+        r = (eye + q) @ (eye - q).float().inverse().to(target.dtype)
+        return r
+
+    def _make_weight(self, target: torch.Tensor):
+        """Apply the butterfly cascade to ``target`` and return the transformed weight.
+
+        Direct port of :meth:`ButterflyOFTModule.make_weight` (LyCORIS
+        boft.py:158-191) for the merge-mode (no-bypass) path. ``target`` is the
+        host weight; iteratively reshape to expose the per-stage block layout,
+        einsum-multiply by the stage rotation, then reshape back. The reshape
+        recipe at each stage is what makes the rotations interleave across
+        butterfly partitions, giving the algorithm its O(d log d) parameter
+        density.
+        """
+        m = self.boft_m
+        b = self.boft_b
+        r_b = b // 2
+        r = self._get_r(target)
+        inp = target
+
+        for i in range(m):
+            bi = r[i]
+            g = 2
+            k = 2 ** i * r_b
+            inp = (
+                inp.unflatten(0, (-1, g, k))
+                .transpose(1, 2)
+                .flatten(0, 2)
+                .unflatten(0, (-1, b))
+            )
+            inp = torch.einsum("b i j, b j ... -> b i ...", bi, inp)
+            inp = (
+                inp.flatten(0, 1).unflatten(0, (-1, k, g)).transpose(1, 2).flatten(0, 2)
+            )
+
+        if self.rescale is not None:
+            inp = inp * self.rescale.to(target.device, dtype=target.dtype)
+        return inp
+
+    def calc_updown(self, target: torch.Tensor):
+        merged = self._make_weight(target)
+        updown = merged - target
+        return self.finalize_updown(updown, target, target.shape)

--- a/modules/lora/network_glora.py
+++ b/modules/lora/network_glora.py
@@ -19,6 +19,7 @@ class NetworkModuleGLora(network.NetworkModule): # pylint: disable=abstract-meth
         self.w1b = weights.w["b1.weight"]
         self.w2a = weights.w["a2.weight"]
         self.w2b = weights.w["b2.weight"]
+        self.dim = self.w1b.shape[0]
 
     def calc_updown(self, target): # pylint: disable=arguments-differ
         w1a = self.w1a.to(target.device, dtype=target.dtype)

--- a/modules/lora/network_hada.py
+++ b/modules/lora/network_hada.py
@@ -1,3 +1,4 @@
+import torch
 import modules.lora.lyco_helpers as lyco_helpers
 import modules.lora.network as network
 
@@ -42,5 +43,40 @@ class NetworkModuleHada(network.NetworkModule): # pylint: disable=abstract-metho
             updown2 = lyco_helpers.make_weight_cp(t2, w2a, w2b)
         else:
             updown2 = lyco_helpers.rebuild_conventional(w2a, w2b, output_shape)
+        updown = updown1 * updown2
+        return self.finalize_updown(updown, target, output_shape)
+
+
+class NetworkModuleHadaChunk(NetworkModuleHada):
+    """LoHA module that returns one row chunk of the Hadamard product.
+
+    Used when a LoHA adapter targets a fused weight (e.g., img_attn.qkv) but the
+    diffusers model exposes separate Q/K/V modules. Slices the row-side of each
+    Hadamard arm (w1a, w2a) at the assigned chunk's row range and computes the
+    partial product. Memory and compute scale linearly with chunk size; no full
+    Hadamard temporary is materialized.
+
+    Tucker (CP-decomposed) LoHAs are not handled here. LyCORIS only saves
+    hada_t1 / hada_t2 for non-1x1 Conv layers, and fused QKV is always Linear,
+    so this combination cannot arise from a conformant trainer.
+    """
+
+    def __init__(self, net, weights, chunk_index, num_chunks):
+        super().__init__(net, weights)
+        self.chunk_index = chunk_index
+        self.num_chunks = num_chunks
+
+    def calc_updown(self, target):
+        w1a = self.w1a.to(target.device, dtype=target.dtype)
+        w1b = self.w1b.to(target.device, dtype=target.dtype)
+        w2a = self.w2a.to(target.device, dtype=target.dtype)
+        w2b = self.w2b.to(target.device, dtype=target.dtype)
+        w1a_chunk = torch.chunk(w1a, self.num_chunks, dim=0)[self.chunk_index].contiguous()
+        w2a_chunk = torch.chunk(w2a, self.num_chunks, dim=0)[self.chunk_index].contiguous()
+        output_shape = [w1a_chunk.size(0), w1b.size(1)]
+        if len(w1b.shape) == 4:
+            output_shape += w1b.shape[2:]
+        updown1 = lyco_helpers.rebuild_conventional(w1a_chunk, w1b, output_shape)
+        updown2 = lyco_helpers.rebuild_conventional(w2a_chunk, w2b, output_shape)
         updown = updown1 * updown2
         return self.finalize_updown(updown, target, output_shape)

--- a/modules/lora/network_oft.py
+++ b/modules/lora/network_oft.py
@@ -55,7 +55,7 @@ class NetworkModuleOFT(network.NetworkModule): # pylint: disable=abstract-method
     def calc_updown(self, target):
         oft_blocks = self.oft_blocks.to(target.device, dtype=target.dtype)
         eye = torch.eye(self.block_size, device=target.device)
-        constraint = self.constraint.to(target.device)
+        constraint = self.constraint.to(target.device) if self.constraint is not None else None
 
         if self.is_kohya:
             block_Q = oft_blocks - oft_blocks.transpose(1, 2) # ensure skew-symmetric orthogonal matrix

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -38,7 +38,7 @@ import time
 import torch
 from modules import shared, sd_models
 from modules.logger import log
-from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, network_ia3, lora_convert
+from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, network_ia3, network_glora, lora_convert
 from modules.lora import lora_common as l
 
 
@@ -86,12 +86,18 @@ IA3_SUFFIXES = (
     ".weight", ".on_input",
     ".alpha", ".scale",
 )
+GLORA_SUFFIXES = (
+    ".a1.weight", ".a2.weight",
+    ".b1.weight", ".b2.weight",
+    ".alpha", ".dora_scale", ".scale",
+)
 
 LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
 LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
 LOHA_MARKERS = (".hada_w1_a", ".hada_w1_b", ".hada_w2_a", ".hada_w2_b")
 OFT_MARKERS = (".oft_blocks", ".oft_diag")
 IA3_MARKERS = (".on_input",)  # NOT .weight — too generic, overlaps every other family
+GLORA_MARKERS = (".a1.weight", ".a2.weight", ".b1.weight", ".b2.weight")
 
 
 # === BFL → diffusers mapping ===
@@ -521,6 +527,50 @@ def try_load_ia3(name, network_on_disk, lora_scale):
             net.modules[network_key] = network_ia3.NetworkModuleIa3(net, nw)
 
     return finalize_network(net, name, 'IA3', lora_scale, t0, unmapped=unmapped, skipped=skipped)
+
+
+def try_load_glora(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein GLoRA adapter as native modules.
+
+    GLoRA stores four low-rank components (``a1``/``a2``/``b1``/``b2``) and
+    computes ``ΔW = w2b @ w1b + (target @ w2a) @ w1a`` — the second term is
+    target-dependent. Fused QKV in double_blocks is skipped with a warning
+    because the target-dependent term doesn't slice cleanly without
+    redirecting calc_updown to a fused proxy weight, and zero real-world
+    GLoRA-on-DiT files exist.
+
+    Depends on the ``self.dim`` initialization fix in network_glora.py so
+    that alpha-based ``calc_scale`` is honored.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, GLORA_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, GLORA_SUFFIXES)
+
+    unmapped = 0
+    skipped = 0
+    for (prefix, base), w in groups.items():
+        if not all(k in w for k in ('a1.weight', 'a2.weight', 'b1.weight', 'b2.weight')):
+            continue
+        targets = resolve_targets(prefix, base)
+        if any(t[1] is not None for t in targets):
+            log.warning(f'Network load: type=GLoRA name="{name}" key={base} fused QKV skipped (unsupported)')
+            skipped += 1
+            continue
+        for diffusers_path, _, _ in targets:
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
+            net.modules[network_key] = network_glora.NetworkModuleGLora(net, nw)
+
+    return finalize_network(net, name, 'GLoRA', lora_scale, t0, unmapped=unmapped, skipped=skipped)
 
 
 # === Diffusers-PEFT path helpers (used when lora_force_diffusers is on) ===

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -38,7 +38,7 @@ import time
 import torch
 from modules import shared, sd_models
 from modules.logger import log
-from modules.lora import network, network_lora, network_lokr, lora_convert
+from modules.lora import network, network_lora, network_lokr, network_hada, lora_convert
 from modules.lora import lora_common as l
 
 
@@ -72,9 +72,16 @@ LOKR_SUFFIXES = (
     ".lokr_t2",
     ".alpha", ".dora_scale", ".bias", ".scale",
 )
+LOHA_SUFFIXES = (
+    ".hada_w1_a", ".hada_w1_b",
+    ".hada_w2_a", ".hada_w2_b",
+    ".hada_t1",   ".hada_t2",
+    ".alpha", ".dora_scale", ".bias", ".scale",
+)
 
 LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
 LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
+LOHA_MARKERS = (".hada_w1_a", ".hada_w1_b", ".hada_w2_a", ".hada_w2_b")
 
 
 # === BFL → diffusers mapping ===
@@ -369,6 +376,52 @@ def try_load_lokr(name, network_on_disk, lora_scale):
                 net.modules[network_key] = network_lokr.NetworkModuleLokr(net, nw)
 
     return finalize_network(net, name, 'LoKR', lora_scale, t0, unmapped=unmapped)
+
+
+def try_load_loha(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein LoHA (Hadamard product) adapter as native modules.
+
+    Standard non-Tucker LoHA on fused QKV in double_blocks is supported via
+    :class:`NetworkModuleHadaChunk`, which slices ``w1a``/``w2a`` at the
+    chunk's row range and computes the partial Hadamard. Tucker
+    (CP-decomposed) LoHAs are skipped on fused targets because the chunk
+    class does not implement the CP path; non-fused Tucker LoHAs go through
+    the standard :class:`NetworkModuleHada`.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, LOHA_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, LOHA_SUFFIXES)
+
+    unmapped = 0
+    skipped = 0
+    for (prefix, base), w in groups.items():
+        if not all(k in w for k in ('hada_w1_a', 'hada_w1_b', 'hada_w2_a', 'hada_w2_b')):
+            continue
+        is_tucker = 'hada_t1' in w or 'hada_t2' in w
+        targets = resolve_targets(prefix, base)
+        is_fused = any(t[1] is not None for t in targets)
+        if is_fused and is_tucker:
+            log.warning(f'Network load: type=LoHA name="{name}" key={base} Tucker fused QKV skipped (unsupported)')
+            skipped += 1
+            continue
+        for diffusers_path, chunk_idx, num_chunks in targets:
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
+            if chunk_idx is not None:
+                net.modules[network_key] = network_hada.NetworkModuleHadaChunk(net, nw, chunk_idx, num_chunks)
+            else:
+                net.modules[network_key] = network_hada.NetworkModuleHada(net, nw)
+
+    return finalize_network(net, name, 'LoHA', lora_scale, t0, unmapped=unmapped, skipped=skipped)
 
 
 # === Diffusers-PEFT path helpers (used when lora_force_diffusers is on) ===

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -38,7 +38,10 @@ import time
 import torch
 from modules import shared, sd_models
 from modules.logger import log
-from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, network_ia3, network_glora, network_norm, lora_convert
+from modules.lora import (
+    network, network_lora, network_lokr, network_hada, network_oft,
+    network_ia3, network_glora, network_norm, network_full, lora_convert,
+)
 from modules.lora import lora_common as l
 
 
@@ -95,6 +98,10 @@ NORM_SUFFIXES = (
     ".w_norm", ".b_norm",
     ".alpha", ".scale",
 )
+FULL_SUFFIXES = (
+    ".diff", ".diff_b",
+    ".alpha", ".scale",
+)
 
 LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
 LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
@@ -103,6 +110,7 @@ OFT_MARKERS = (".oft_blocks", ".oft_diag")
 IA3_MARKERS = (".on_input",)  # NOT .weight — too generic, overlaps every other family
 GLORA_MARKERS = (".a1.weight", ".a2.weight", ".b1.weight", ".b2.weight")
 NORM_MARKERS = (".w_norm",)
+FULL_MARKERS = (".diff",)
 
 
 # === BFL → diffusers mapping ===
@@ -634,6 +642,51 @@ def try_load_norm(name, network_on_disk, lora_scale):
             net.modules[network_key] = network_norm.NetworkModuleNorm(net, nw)
 
     return finalize_network(net, name, 'Norm', lora_scale, t0, unmapped=unmapped)
+
+
+def try_load_full(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein Full (full-rank) adapter as native modules.
+
+    Full adapters carry a complete weight delta (``diff``, same shape as the
+    host weight) and an optional bias delta (``diff_b``) via
+    :class:`NetworkModuleFull`. Most realistic use: small per-block bias-only
+    adjustments in distillation LoRAs.
+
+    Fused QKV in double_blocks is skipped with a warning. Full's ``diff`` has
+    the host weight's full shape; row-slicing across three projections is
+    well-defined arithmetically but no chunk class exists and zero
+    real-world Full-on-fused-DiT files exist. Single-block linear1 (a single
+    fused diffusers module) and non-QKV double-block targets work fully.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, FULL_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, FULL_SUFFIXES)
+
+    unmapped = 0
+    skipped = 0
+    for (prefix, base), w in groups.items():
+        if 'diff' not in w:
+            continue
+        targets = resolve_targets(prefix, base)
+        if any(t[1] is not None for t in targets):
+            log.warning(f'Network load: type=Full name="{name}" key={base} fused QKV skipped (unsupported)')
+            skipped += 1
+            continue
+        for diffusers_path, _, _ in targets:
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
+            net.modules[network_key] = network_full.NetworkModuleFull(net, nw)
+
+    return finalize_network(net, name, 'Full', lora_scale, t0, unmapped=unmapped, skipped=skipped)
 
 
 # === Diffusers-PEFT path helpers (used when lora_force_diffusers is on) ===

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -6,8 +6,13 @@ sdnext's existing ``network_layer_mapping``, returning a ``Network`` populated
 with ``NetworkModule*`` entries that ``network_activate`` will apply.
 
 Recognized key prefixes for every family: ``diffusion_model.``,
-``transformer.``, ``lora_unet_``, or bare BFL (no prefix). Diffusers-PEFT
-``lora_A``/``lora_B`` are normalized to ``lora_down``/``lora_up``.
+``transformer.``, ``lora_unet_``, ``lycoris_``, ``base_model.model.``
+(PEFT save wrapper), bare BFL paths (e.g. ``double_blocks.``), and bare
+diffusers paths (``transformer_blocks.`` / ``single_transformer_blocks.``,
+produced by ``Flux2Transformer2DModel.save_lora_adapter()``). Diffusers-PEFT
+``lora_A``/``lora_B`` are normalized to ``lora_down``/``lora_up`` and a
+``.<adapter_name>.`` infix between the suffix and ``.weight`` (e.g.
+``.lora_A.default.weight``) is stripped to match the standard suffix table.
 
 BFL/kohya keys are mapped to diffusers paths via ``F2_SINGLE_MAP`` /
 ``F2_DOUBLE_MAP`` / ``F2_QKV_MAP``. Fused QKV in double_blocks is split into
@@ -47,13 +52,30 @@ from modules.lora import lora_common as l
 
 # === Format detection ===
 
-KNOWN_PREFIXES = ("diffusion_model.", "transformer.", "lora_unet_")
+# Prefixes we recognize as the "true" format-identifying prefix on a state-dict
+# key. The PEFT save wrapper ``base_model.model.`` is handled separately as a
+# pre-strip step (see :func:`_unwrap_peft_wrapper`) because it can wrap any of
+# the prefixes below — peft.save_pretrained prepends it indiscriminately.
+#
+# - ``diffusion_model.`` — AI-toolkit / BFL native (e.g. ostris/ai-toolkit)
+# - ``transformer.``      — diffusers PEFT in-memory (e.g. HF DreamBooth scripts)
+# - ``lora_unet_``        — kohya-ss/sd-scripts standard
+# - ``lycoris_``          — LyCORIS-standalone save (e.g. SimpleTuner LoKR);
+#                           the path under this prefix is an underscore-rendered
+#                           diffusers path, not a BFL path
+KNOWN_PREFIXES = ("diffusion_model.", "transformer.", "lora_unet_", "lycoris_")
 
 BARE_FLUX_PREFIXES = (
     "single_blocks.", "double_blocks.", "img_in.", "txt_in.",
     "final_layer.", "time_in.", "single_stream_modulation.",
     "double_stream_modulation_",
 )
+
+# Bare diffusers paths (no wrapping prefix) — produced by
+# ``Flux2Transformer2DModel.save_lora_adapter()`` after attaching a PEFT adapter.
+# These are already-diffusers paths and pass through ``resolve_targets`` verbatim.
+BARE_DIFFUSERS_PREFIXES = ("single_transformer_blocks.", "transformer_blocks.")
+BARE_DIFFUSERS_PREFIX_USED = "bare_diffusers"  # sentinel value for ``parse_key`` return
 
 SUFFIX_NORMALIZE = {
     "lora_A.weight": "lora_down.weight",
@@ -103,7 +125,13 @@ FULL_SUFFIXES = (
     ".alpha", ".scale",
 )
 
-LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
+LORA_MARKERS = (
+    ".lora_down.weight", ".lora_up.weight",
+    ".lora_A.weight", ".lora_B.weight",
+    # PEFT named-adapter saves embed the slot name as ``.lora_A.<name>.weight``;
+    # the trailing-dot forms catch every variant.
+    ".lora_A.", ".lora_B.",
+)
 LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
 LOHA_MARKERS = (".hada_w1_a", ".hada_w1_b", ".hada_w2_a", ".hada_w2_b")
 OFT_MARKERS = (".oft_blocks", ".oft_diag")
@@ -200,13 +228,59 @@ def shapes_match(sd_module, down_w: torch.Tensor, up_w: torch.Tensor) -> bool:
     return down_w.shape[1] == mod_shape[1] and up_w.shape[0] == mod_shape[0]
 
 
+def _unwrap_peft_wrapper(key):
+    """Strip the ``base_model.model.`` prefix added by ``peft.save_pretrained``.
+
+    PeftModel.save_pretrained prepends this wrapper to every adapter key. The
+    content underneath can be any of the formats KNOWN_PREFIXES already handle:
+
+    - BFL keys (e.g. fal/flux-2-klein-4B-outpaint-lora:
+      ``base_model.model.double_blocks.0.img_attn.proj.lora_A.weight``)
+    - Diffusers paths under ``transformer.`` (HF DreamBooth scripts that
+      target diffusers modules and let peft wrap them)
+    - Bare-BFL keys (rare but possible)
+
+    Stripping the wrapper once is enough; the rest of :func:`parse_key` then
+    matches the unwrapped key against KNOWN_PREFIXES or the bare-BFL fallback
+    normally. Mirrors the diffusers ``Flux2LoraLoaderMixin.lora_state_dict``
+    behavior at lora_pipeline.py:5684-5686, which renames the prefix to
+    ``diffusion_model.`` before feeding the key to the AI-toolkit converter.
+    """
+    if key.startswith("base_model.model."):
+        return key[len("base_model.model."):]
+    return key
+
+
+def _strip_peft_adapter_name(key):
+    """Normalize ``.lora_[AB].<adapter_name>.weight`` to ``.lora_[AB].weight``.
+
+    ``peft.PeftModel`` and the diffusers ``save_lora_adapter`` exporter embed the
+    adapter slot name into the saved key (``"default"`` when not explicitly
+    set). Strip a single non-dotted name segment so the suffix table matches
+    without listing every plausible adapter name.
+    """
+    for inner in (".lora_A.", ".lora_B."):
+        idx = key.find(inner)
+        if idx == -1:
+            continue
+        rest = key[idx + len(inner):]
+        if rest == "weight" or not rest.endswith(".weight"):
+            continue
+        adapter_name = rest[:-len(".weight")]
+        if adapter_name and "." not in adapter_name:
+            return key[:idx] + inner + "weight"
+    return key
+
+
 def parse_key(key, suffixes):
     """Return ``(prefix_used, base, suffix_normalized)`` or ``None``.
 
     ``prefix_used`` is the matched ``KNOWN_PREFIXES`` element, or ``None`` for
-    bare BFL keys. ``base`` is the format-native module path (kohya
-    underscore-style or BFL/diffusers dot-style depending on prefix).
+    bare BFL keys. ``base`` is the format-native module path (kohya / lycoris
+    underscore-style or BFL / diffusers dot-style depending on prefix).
     """
+    key = _unwrap_peft_wrapper(key)
+    key = _strip_peft_adapter_name(key)
     prefix_used = None
     stripped = key
     for p in KNOWN_PREFIXES:
@@ -215,7 +289,9 @@ def parse_key(key, suffixes):
             stripped = key[len(p):]
             break
     if prefix_used is None:
-        if not any(key.startswith(p) for p in BARE_FLUX_PREFIXES):
+        if any(key.startswith(p) for p in BARE_DIFFUSERS_PREFIXES):
+            prefix_used = BARE_DIFFUSERS_PREFIX_USED
+        elif not any(key.startswith(p) for p in BARE_FLUX_PREFIXES):
             return None
 
     matched_suffix = None
@@ -269,6 +345,18 @@ def resolve_targets(prefix_used, base):
     if prefix_used in (None, 'diffusion_model.'):
         return _bfl_to_diffusers_targets(base)
     if prefix_used == 'transformer.':
+        return [(base, None, None)]
+    if prefix_used == BARE_DIFFUSERS_PREFIX_USED:
+        # Already-diffusers path with no wrapping prefix (e.g. produced by
+        # Flux2Transformer2DModel.save_lora_adapter()). Pass through verbatim.
+        return [(base, None, None)]
+    if prefix_used == 'lycoris_':
+        # base is an already-underscored diffusers path (e.g.
+        # 'transformer_blocks_0_attn_add_k_proj'). The caller's network_key
+        # construction does base.replace('.', '_'); for already-underscored
+        # paths that's a no-op, so the network_key matches the entry stamped
+        # by lora_convert.assign_network_names_to_compvis_modules
+        # (e.g. 'lora_transformer_transformer_blocks_0_attn_add_k_proj').
         return [(base, None, None)]
     return []
 

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -423,6 +423,32 @@ def _bfl_to_diffusers_targets(base):
 # === Native loaders ===
 
 
+def try_load(name, network_on_disk, lora_scale):
+    """Run every Flux2 family loader in dispatch order, merge any that match.
+
+    Per-family ``try_load_*`` entry points stay public; this is the single
+    umbrella the dispatcher in ``modules.lora.lora_load.load_safetensors``
+    calls. Order matters only for marker-cost: LoRA / LoKR are most common
+    so their fast bail-out runs first; the rare families come last.
+
+    Returns a ``Network`` with the union of modules from every matching
+    family loader, or ``None`` if no loader recognized the file.
+    """
+    net = None
+    for try_fn in (
+        try_load_lora, try_load_lokr, try_load_loha, try_load_oft,
+        try_load_ia3, try_load_glora, try_load_norm, try_load_full,
+    ):
+        sub = try_fn(name, network_on_disk, lora_scale)
+        if sub is None:
+            continue
+        if net is None:
+            net = sub
+        else:
+            net.modules.update(sub.modules)
+    return net
+
+
 def try_load_lora(name, network_on_disk, lora_scale):
     """Load a Flux2/Klein LoRA (plus DoRA via the universal ``finalize_updown`` hook) as native modules.
 

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -32,6 +32,23 @@ Per-family fused-QKV handling:
   warning.
 - Norm: targets 1-D LayerNorm/RMSNorm parameters; never fused.
 
+LyCORIS algorithm coverage relative to upstream
+``KohakuBlueleaf/LyCORIS/lycoris/modules/``:
+
+- Native: LoRA, LoKR, LoHA, OFT, BOFT, IA3, GLoRA, Norm, Full.
+- Saved as standard LoRA: LoCon and DyLoRA. Both ``custom_state_dict``
+  outputs collapse to ``lora_up.weight``/``lora_down.weight``/``alpha``
+  (LoCon bakes its ``scalar`` into ``lora_up``; DyLoRA concats its
+  per-block slabs into a max-rank matrix), so ``try_load_lora`` loads
+  them losslessly relative to upstream's own export.
+- Deferred: TLoRA. The file saves only ``q_layer.weight`` /
+  ``p_layer.weight`` / ``lambda_layer`` / ``alpha``; the base SVD
+  reference (``base_q`` / ``base_p`` / ``base_lambda``) that the
+  delta math subtracts is unsaved by upstream design and the
+  ``sig_type`` selection mode is unrecoverable from the file, so
+  any loader has a silent-correctness gap for ``sig_type != 'principal'``.
+  Files fail cleanly with "not loaded".
+
 Diffusers-PEFT fallback (used when ``lora_force_diffusers`` is on) is preserved
 via :func:`apply_patch`, which monkey-patches ``Flux2LoraLoaderMixin.lora_state_dict``
 to inject the ``diffusion_model.`` prefix for bare-BFL keys and bake kohya
@@ -44,7 +61,7 @@ import torch
 from modules import shared, sd_models
 from modules.logger import log
 from modules.lora import (
-    network, network_lora, network_lokr, network_hada, network_oft,
+    network, network_lora, network_lokr, network_hada, network_oft, network_boft,
     network_ia3, network_glora, network_norm, network_full, lora_convert,
 )
 from modules.lora import lora_common as l
@@ -542,15 +559,24 @@ def try_load_loha(name, network_on_disk, lora_scale):
 
 
 def try_load_oft(name, network_on_disk, lora_scale):
-    """Load a Flux2/Klein OFT (Orthogonal Fine-Tuning) adapter as native modules.
+    """Load a Flux2/Klein OFT or BOFT adapter as native modules.
 
-    Both kohya (``oft_blocks`` + alpha-as-constraint) and LyCORIS
-    (``oft_diag``) layouts are recognized via :class:`NetworkModuleOFT`.
-    Fused QKV in double_blocks is skipped with a warning: an OFT block
-    structure is tied to the target module's ``out_features``, so a per-Q/K/V
-    split would require re-deriving the rotation per chunk and is not a
-    drop-in. Single-block linear1 (a single fused diffusers module) and all
-    non-QKV double-block targets work fully.
+    Both algorithms share the ``oft_blocks`` save key and are discriminated
+    by tensor dimensionality, mirroring LyCORIS's own ``algo_check``:
+
+    - **OFT** — 3-D ``(num_blocks, block_size, block_size)``. Both kohya
+      (``oft_blocks`` + alpha-as-constraint) and LyCORIS (``oft_diag``)
+      layouts route through :class:`NetworkModuleOFT`.
+    - **BOFT** — 4-D ``(boft_m, block_num, block_size, block_size)``,
+      a cascade of butterfly factors. Routes through
+      :class:`NetworkModuleBOFT` which ports the butterfly-cascade
+      ``make_weight`` from LyCORIS boft.py.
+
+    Fused QKV in double_blocks is skipped with a warning for both: an OFT
+    block structure (and BOFT's per-stage block partition) is tied to the
+    target module's ``out_features``, so a per-Q/K/V split would require
+    re-deriving the rotations per chunk. Single-block ``linear1`` (a single
+    fused diffusers module) and all non-QKV double-block targets work fully.
     """
     t0 = time.time()
     state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
@@ -566,9 +592,10 @@ def try_load_oft(name, network_on_disk, lora_scale):
     for (prefix, base), w in groups.items():
         if not ('oft_blocks' in w or 'oft_diag' in w):
             continue
+        is_boft = 'oft_blocks' in w and w['oft_blocks'].ndim == 4
         targets = resolve_targets(prefix, base)
         if any(t[1] is not None for t in targets):
-            log.warning(f'Network load: type=OFT name="{name}" key={base} fused QKV skipped (unsupported)')
+            log.warning(f'Network load: type={"BOFT" if is_boft else "OFT"} name="{name}" key={base} fused QKV skipped (unsupported)')
             skipped += 1
             continue
         for diffusers_path, _, _ in targets:
@@ -578,7 +605,10 @@ def try_load_oft(name, network_on_disk, lora_scale):
                 unmapped += 1
                 continue
             nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
-            net.modules[network_key] = network_oft.NetworkModuleOFT(net, nw)
+            if is_boft:
+                net.modules[network_key] = network_boft.NetworkModuleBOFT(net, nw)
+            else:
+                net.modules[network_key] = network_oft.NetworkModuleOFT(net, nw)
 
     return finalize_network(net, name, 'OFT', lora_scale, t0, unmapped=unmapped, skipped=skipped)
 

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -38,7 +38,7 @@ import time
 import torch
 from modules import shared, sd_models
 from modules.logger import log
-from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, lora_convert
+from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, network_ia3, lora_convert
 from modules.lora import lora_common as l
 
 
@@ -82,11 +82,16 @@ OFT_SUFFIXES = (
     ".oft_blocks", ".oft_diag",
     ".alpha", ".dora_scale", ".bias", ".scale",
 )
+IA3_SUFFIXES = (
+    ".weight", ".on_input",
+    ".alpha", ".scale",
+)
 
 LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
 LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
 LOHA_MARKERS = (".hada_w1_a", ".hada_w1_b", ".hada_w2_a", ".hada_w2_b")
 OFT_MARKERS = (".oft_blocks", ".oft_diag")
+IA3_MARKERS = (".on_input",)  # NOT .weight — too generic, overlaps every other family
 
 
 # === BFL → diffusers mapping ===
@@ -469,6 +474,53 @@ def try_load_oft(name, network_on_disk, lora_scale):
             net.modules[network_key] = network_oft.NetworkModuleOFT(net, nw)
 
     return finalize_network(net, name, 'OFT', lora_scale, t0, unmapped=unmapped, skipped=skipped)
+
+
+def try_load_ia3(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein IA3 adapter as native modules.
+
+    IA3 stores a per-row or per-column scale vector keyed under ``.weight``
+    plus an ``.on_input`` flag selecting which axis. The ``.on_input`` marker
+    is the format disambiguator — ``.weight`` alone is too generic and
+    overlaps every other family's ``.lora_down.weight`` / ``.hada_w*`` keys,
+    so the SUFFIXES table includes it but the MARKERS gate insists on
+    ``.on_input``.
+
+    Fused QKV in double_blocks is skipped: ``on_input=True`` IA3 vectors
+    would replicate cleanly to Q/K/V (same ``in_features``) but
+    ``on_input=False`` requires slicing the output-axis vector across the
+    three projections, and there is zero real-world IA3-on-DiT prevalence to
+    justify the asymmetry.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, IA3_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, IA3_SUFFIXES)
+
+    unmapped = 0
+    skipped = 0
+    for (prefix, base), w in groups.items():
+        if not ('weight' in w and 'on_input' in w):
+            continue
+        targets = resolve_targets(prefix, base)
+        if any(t[1] is not None for t in targets):
+            log.warning(f'Network load: type=IA3 name="{name}" key={base} fused QKV skipped (unsupported)')
+            skipped += 1
+            continue
+        for diffusers_path, _, _ in targets:
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
+            net.modules[network_key] = network_ia3.NetworkModuleIa3(net, nw)
+
+    return finalize_network(net, name, 'IA3', lora_scale, t0, unmapped=unmapped, skipped=skipped)
 
 
 # === Diffusers-PEFT path helpers (used when lora_force_diffusers is on) ===

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -1,11 +1,36 @@
-"""Flux2/Klein-specific LoRA loading.
+"""Flux2/Klein native adapter loader.
 
-Handles:
-- Kohya-format LoRA via native module loading (lora_unet_ prefix keys)
-- LoKR adapters via native module loading (bypasses diffusers PEFT system)
-- Bare BFL-format keys in state dicts (adds diffusion_model. prefix for converter)
+Runs when :func:`modules.lora.lora_overrides.get_method` returns ``'native'``
+(``f2`` in ``allow_native``). Reads the safetensors directly and writes into
+sdnext's existing ``network_layer_mapping``, returning a ``Network`` populated
+with ``NetworkModule*`` entries that ``network_activate`` will apply.
 
-Installed via apply_patch() during pipeline loading.
+Recognized key prefixes for every family: ``diffusion_model.``,
+``transformer.``, ``lora_unet_``, or bare BFL (no prefix). Diffusers-PEFT
+``lora_A``/``lora_B`` are normalized to ``lora_down``/``lora_up``.
+
+BFL/kohya keys are mapped to diffusers paths via ``F2_SINGLE_MAP`` /
+``F2_DOUBLE_MAP`` / ``F2_QKV_MAP``. Fused QKV in double_blocks is split into
+three Q/K/V targets at lookup time. PEFT keys are diffusers paths already and
+are returned verbatim with no chunking.
+
+Per-family fused-QKV handling:
+
+- LoRA: load-time chunk of ``lora_up`` along dim 0 (the down-side is shared).
+- LoKR: apply-time slice via :class:`NetworkModuleLokrChunk`, which builds
+  ``kron(w1, w2)`` once and returns the designated row range.
+- LoHA: apply-time slice via :class:`NetworkModuleHadaChunk`, which slices
+  ``w1a``/``w2a`` and computes the partial Hadamard product. Tucker
+  (CP-decomposed) LoHAs are not chunked and are skipped on fused targets.
+- OFT, IA3, GLoRA, Full: no chunk class exists and the math is not row-sliceable
+  without re-deriving per-projection structure. Fused groups are skipped with a
+  warning.
+- Norm: targets 1-D LayerNorm/RMSNorm parameters; never fused.
+
+Diffusers-PEFT fallback (used when ``lora_force_diffusers`` is on) is preserved
+via :func:`apply_patch`, which monkey-patches ``Flux2LoraLoaderMixin.lora_state_dict``
+to inject the ``diffusion_model.`` prefix for bare-BFL keys and bake kohya
+``.alpha`` scaling into ``lora_down`` weights.
 """
 
 import os
@@ -13,19 +38,55 @@ import time
 import torch
 from modules import shared, sd_models
 from modules.logger import log
-from modules.lora import network, network_lokr, network_lora, lora_convert
+from modules.lora import network, network_lora, network_lokr, lora_convert
 from modules.lora import lora_common as l
 
 
-BARE_FLUX_PREFIXES = ("single_blocks.", "double_blocks.", "img_in.", "txt_in.",
-                      "final_layer.", "time_in.", "single_stream_modulation.",
-                      "double_stream_modulation_")
+# === Format detection ===
 
-# BFL -> diffusers module path mapping for Flux2/Klein
+KNOWN_PREFIXES = ("diffusion_model.", "transformer.", "lora_unet_")
+
+BARE_FLUX_PREFIXES = (
+    "single_blocks.", "double_blocks.", "img_in.", "txt_in.",
+    "final_layer.", "time_in.", "single_stream_modulation.",
+    "double_stream_modulation_",
+)
+
+SUFFIX_NORMALIZE = {
+    "lora_A.weight": "lora_down.weight",
+    "lora_B.weight": "lora_up.weight",
+}
+
+
+# === Family suffix tables (alpha / scale / bias / dora_scale flow into weights.w via base NetworkModule.__init__) ===
+
+LORA_SUFFIXES = (
+    ".lora_down.weight", ".lora_up.weight", ".lora_mid.weight",
+    ".lora_A.weight",    ".lora_B.weight",
+    ".alpha", ".dora_scale", ".bias", ".scale",
+)
+LOKR_SUFFIXES = (
+    ".lokr_w1", ".lokr_w2",
+    ".lokr_w1_a", ".lokr_w1_b",
+    ".lokr_w2_a", ".lokr_w2_b",
+    ".lokr_t2",
+    ".alpha", ".dora_scale", ".bias", ".scale",
+)
+
+LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
+LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
+
+
+# === BFL → diffusers mapping ===
+
+# Single-block (single_transformer_blocks.{i}.<target>) — both projections are single fused diffusers modules,
+# so no chunking is needed for any adapter family.
 F2_SINGLE_MAP = {
     'linear1': 'attn.to_qkv_mlp_proj',
     'linear2': 'attn.to_out',
 }
+
+# Double-block non-QKV targets (transformer_blocks.{i}.<target>).
 F2_DOUBLE_MAP = {
     'img_attn.proj': 'attn.to_out.0',
     'txt_attn.proj': 'attn.to_add_out',
@@ -34,14 +95,16 @@ F2_DOUBLE_MAP = {
     'txt_mlp.0': 'ff_context.linear_in',
     'txt_mlp.2': 'ff_context.linear_out',
 }
+
+# Double-block fused QKV targets — diffusers exposes Q/K/V as separate modules,
+# so resolve_targets emits three (path, chunk_index, num_chunks=3) entries.
 F2_QKV_MAP = {
     'img_attn.qkv': ('attn', ['to_q', 'to_k', 'to_v']),
     'txt_attn.qkv': ('attn', ['add_q_proj', 'add_k_proj', 'add_v_proj']),
 }
 
-
-# Kohya underscore suffix -> BFL dot suffix (last underscore becomes dot)
-# Used to convert kohya key fragments to look up F2_DOUBLE_MAP / F2_QKV_MAP
+# Kohya underscore suffix → BFL dot suffix (last underscore becomes dot).
+# Used to convert kohya key fragments to look up F2_DOUBLE_MAP / F2_QKV_MAP.
 KOHYA_SUFFIX_MAP = {
     'img_attn_proj': 'img_attn.proj',
     'txt_attn_proj': 'txt_attn.proj',
@@ -54,208 +117,134 @@ KOHYA_SUFFIX_MAP = {
 }
 
 
-def try_load_lora(name, network_on_disk, lora_scale):
-    """Try loading a Flux2/Klein LoRA as native modules.
+# === Shared scaffolding ===
 
-    Handles three key formats:
-    - Kohya: lora_unet_double_blocks_0_img_attn_proj.lora_down.weight
-    - AI toolkit (BFL): diffusion_model.double_blocks.0.img_attn.proj.lora_A.weight
-    - Diffusers PEFT: transformer.single_transformer_blocks.0.attn.to_qkv_mlp_proj.lora_A.weight
 
-    Returns a Network with native modules, or None to fall through to the diffusers path.
-    """
-    t0 = time.time()
-    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
-    has_lora = any('.lora_down.' in k or '.lora_up.' in k or '.lora_A.' in k or '.lora_B.' in k for k in state_dict)
-    if not has_lora:
-        return None
-    is_f2_keys = any(
-        k.startswith(('lora_unet_single_blocks_', 'lora_unet_double_blocks_',
-                       'diffusion_model.single_blocks.', 'diffusion_model.double_blocks.',
-                       'transformer.single_transformer_blocks.', 'transformer.transformer_blocks.'))
-        for k in state_dict
-    )
-    if not is_f2_keys:
-        return None
-    net = load_lora_native(name, network_on_disk, state_dict)
+def has_marker(state_dict, markers):
+    return any(any(m in k for m in markers) for k in state_dict)
+
+
+def resolve_mapping():
+    sd_model = getattr(shared.sd_model, "pipe", shared.sd_model)
+    lora_convert.assign_network_names_to_compvis_modules(sd_model)
+    return getattr(shared.sd_model, 'network_layer_mapping', {}) or {}
+
+
+def new_network(name, network_on_disk):
+    net = network.Network(name, network_on_disk)
+    net.mtime = os.path.getmtime(network_on_disk.filename)
+    return net
+
+
+def finalize_network(net, name, family, lora_scale, t0, unmapped=0, mismatch=0, skipped=0):
     if len(net.modules) == 0:
+        if unmapped or mismatch or skipped:
+            log.debug(
+                f'Network load: type={family} name="{name}" native no-match'
+                f' unmapped={unmapped} mismatch={mismatch} skipped={skipped}'
+            )
         return None
-    log.debug(f'Network load: type=LoRA name="{name}" native modules={len(net.modules)} scale={lora_scale}')
+    log.debug(
+        f'Network load: type={family} name="{name}" native modules={len(net.modules)}'
+        f' unmapped={unmapped} mismatch={mismatch} skipped={skipped} scale={lora_scale}'
+    )
     l.timer.activate += time.time() - t0
     return net
 
 
-def _group_lora_keys(state_dict):
-    """Group LoRA state dict keys into (targets, weights_dict) pairs.
+def shapes_match(sd_module, down_w: torch.Tensor, up_w: torch.Tensor) -> bool:
+    if not hasattr(sd_module, 'weight'):
+        return False
+    if hasattr(sd_module, 'sdnq_dequantizer'):
+        mod_shape = sd_module.sdnq_dequantizer.original_shape
+    else:
+        mod_shape = sd_module.weight.shape
+    if len(mod_shape) < 2 or len(down_w.shape) < 2 or len(up_w.shape) < 2:
+        return False
+    return down_w.shape[1] == mod_shape[1] and up_w.shape[0] == mod_shape[0]
 
-    Normalizes all three formats into a common structure. Weight keys are
-    normalized to lora_down.weight / lora_up.weight regardless of input naming.
-    Returns list of (targets, weights_dict) where targets come from BFL->diffusers mapping.
+
+def parse_key(key, suffixes):
+    """Return ``(prefix_used, base, suffix_normalized)`` or ``None``.
+
+    ``prefix_used`` is the matched ``KNOWN_PREFIXES`` element, or ``None`` for
+    bare BFL keys. ``base`` is the format-native module path (kohya
+    underscore-style or BFL/diffusers dot-style depending on prefix).
     """
-    # Detect format from first relevant key
-    sample = next((k for k in state_dict if '.lora_' in k), None)
-    if sample is None:
-        return []
+    prefix_used = None
+    stripped = key
+    for p in KNOWN_PREFIXES:
+        if key.startswith(p):
+            prefix_used = p
+            stripped = key[len(p):]
+            break
+    if prefix_used is None:
+        if not any(key.startswith(p) for p in BARE_FLUX_PREFIXES):
+            return None
 
-    if sample.startswith('lora_unet_'):
-        return _group_kohya(state_dict)
-    elif sample.startswith('diffusion_model.'):
-        return _group_bfl(state_dict)
-    elif sample.startswith('transformer.'):
-        return _group_peft(state_dict)
+    matched_suffix = None
+    split_at = -1
+    for marker in suffixes:
+        if stripped.endswith(marker):
+            split_at = len(stripped) - len(marker)
+            matched_suffix = marker.lstrip('.')
+            break
+    if split_at < 0:
+        return None
 
-    # Bare BFL keys (no prefix)
-    if any(k.startswith(p) for k in state_dict for p in BARE_FLUX_PREFIXES):
-        return _group_bfl(state_dict, prefix='')
+    base = stripped[:split_at]
+    if not base:
+        return None
 
+    suffix = SUFFIX_NORMALIZE.get(matched_suffix, matched_suffix)
+    return prefix_used, base, suffix
+
+
+def group_by_suffixes(state_dict, suffixes):
+    """Group state_dict entries by ``(prefix_used, base)``.
+
+    Returns ``{(prefix_used, base): {suffix: tensor, ...}}`` where
+    ``prefix_used`` is a ``KNOWN_PREFIXES`` element or ``None`` for bare-BFL.
+    Per-family loaders apply their own key-presence gates on each group.
+    """
+    groups: dict[tuple, dict[str, torch.Tensor]] = {}
+    for key, value in state_dict.items():
+        parsed = parse_key(key, suffixes)
+        if parsed is None:
+            continue
+        prefix_used, base, suffix = parsed
+        slot = groups.get((prefix_used, base))
+        if slot is None:
+            slot = {}
+            groups[(prefix_used, base)] = slot
+        slot[suffix] = value
+    return groups
+
+
+def resolve_targets(prefix_used, base):
+    """Return ``[(diffusers_path, chunk_index, num_chunks), ...]`` for a parsed group key.
+
+    For kohya prefix, applies ``KOHYA_SUFFIX_MAP`` then ``F2_*_MAP``. For
+    BFL/bare-BFL, applies ``F2_*_MAP`` directly. For PEFT (``transformer.``),
+    returns the base verbatim with no chunking — it is already a diffusers path.
+    """
+    if prefix_used == 'lora_unet_':
+        return _kohya_to_diffusers_targets(base)
+    if prefix_used in (None, 'diffusion_model.'):
+        return _bfl_to_diffusers_targets(base)
+    if prefix_used == 'transformer.':
+        return [(base, None, None)]
     return []
 
 
-def _normalize_weight_key(suffix):
-    """lora_A.weight -> lora_down.weight, lora_B.weight -> lora_up.weight"""
-    return suffix.replace('lora_A.', 'lora_down.').replace('lora_B.', 'lora_up.')
-
-
-def _group_kohya(state_dict):
-    """Group kohya-format keys (lora_unet_ prefix, underscored module names)."""
-    groups = {}
-    for key, weight in state_dict.items():
-        if not key.startswith('lora_unet_'):
-            continue
-        base, _, suffix = key.partition('.')
-        if not suffix:
-            continue
-        if base not in groups:
-            groups[base] = {}
-        groups[base][_normalize_weight_key(suffix)] = weight
-
-    results = []
-    for base, weights_dict in groups.items():
-        if 'lora_down.weight' not in weights_dict:
-            continue
-        stripped = base[len('lora_unet_'):]
-        targets = _kohya_key_to_targets(stripped)
-        if targets:
-            results.append((targets, weights_dict))
-    return results
-
-
-def _group_bfl(state_dict, prefix='diffusion_model.'):
-    """Group BFL/AI-toolkit-format keys (dot-separated module names)."""
-    groups = {}
-    for key, weight in state_dict.items():
-        if prefix and not key.startswith(prefix):
-            continue
-        stripped = key[len(prefix):]
-        # Split at lora boundary: double_blocks.0.img_attn.proj.lora_A.weight
-        for marker in ('.lora_A.', '.lora_B.', '.lora_down.', '.lora_up.', '.alpha', '.dora_scale'):
-            pos = stripped.find(marker)
-            if pos != -1:
-                base = stripped[:pos]
-                suffix = stripped[pos + 1:] if stripped[pos + 1:] else marker[1:]  # handle bare .dora_scale / .alpha
-                break
-        else:
-            continue
-        if base not in groups:
-            groups[base] = {}
-        groups[base][_normalize_weight_key(suffix)] = weight
-
-    results = []
-    for base, weights_dict in groups.items():
-        if 'lora_down.weight' not in weights_dict:
-            continue
-        targets = _bfl_key_to_targets(base)
-        if targets:
-            results.append((targets, weights_dict))
-    return results
-
-
-def _group_peft(state_dict):
-    """Group diffusers PEFT-format keys (transformer. prefix, diffusers module names)."""
-    groups = {}
-    for key, weight in state_dict.items():
-        if not key.startswith('transformer.'):
-            continue
-        stripped = key[len('transformer.'):]
-        for marker in ('.lora_A.', '.lora_B.', '.lora_down.', '.lora_up.', '.alpha'):
-            pos = stripped.find(marker)
-            if pos != -1:
-                module_path = stripped[:pos]
-                suffix = stripped[pos + 1:]
-                break
-        else:
-            continue
-        if module_path not in groups:
-            groups[module_path] = {}
-        groups[module_path][_normalize_weight_key(suffix)] = weight
-
-    results = []
-    for module_path, weights_dict in groups.items():
-        if 'lora_down.weight' not in weights_dict:
-            continue
-        # Already in diffusers path format — direct target, no mapping needed
-        results.append(([(module_path, None, None)], weights_dict))
-    return results
-
-
-def load_lora_native(name, network_on_disk, state_dict):
-    """Load Flux2/Klein LoRA as native modules from any supported key format."""
-    sd_model = getattr(shared.sd_model, "pipe", shared.sd_model)
-    lora_convert.assign_network_names_to_compvis_modules(sd_model)
-    net = network.Network(name, network_on_disk)
-    net.mtime = os.path.getmtime(network_on_disk.filename)
-
-    for targets, weights_dict in _group_lora_keys(state_dict):
-        for module_path, chunk_index, num_chunks in targets:
-            network_key = "lora_transformer_" + module_path.replace(".", "_")
-            sd_module = sd_model.network_layer_mapping.get(network_key)
-            if sd_module is None:
-                continue
-
-            w = {}
-            if chunk_index is not None:
-                up = weights_dict['lora_up.weight']
-                chunks = torch.chunk(up, num_chunks, dim=0)
-                w['lora_up.weight'] = chunks[chunk_index].contiguous()
-                w['lora_down.weight'] = weights_dict['lora_down.weight']
-            else:
-                w['lora_up.weight'] = weights_dict['lora_up.weight']
-                w['lora_down.weight'] = weights_dict['lora_down.weight']
-
-            # Validate dimensions match the target module
-            if hasattr(sd_module, 'weight'):
-                if hasattr(sd_module, 'sdnq_dequantizer'):
-                    mod_shape = sd_module.sdnq_dequantizer.original_shape
-                else:
-                    mod_shape = sd_module.weight.shape
-                if w['lora_down.weight'].shape[1] != mod_shape[1] or w['lora_up.weight'].shape[0] != mod_shape[0]:
-                    log.warning(f'Network load: type=LoRA shape mismatch: {network_key} lora={w["lora_down.weight"].shape[1]}x{w["lora_up.weight"].shape[0]} module={mod_shape[1]}x{mod_shape[0]}')
-                    continue
-
-            if 'alpha' in weights_dict:
-                w['alpha'] = weights_dict['alpha']
-            if 'dora_scale' in weights_dict:
-                w['dora_scale'] = weights_dict['dora_scale']
-
-            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
-            net.modules[network_key] = network_lora.NetworkModuleLora(net, nw)
-
-    return net
-
-
-def _kohya_key_to_targets(stripped):
-    """Map a stripped kohya key to (diffusers_module_path, chunk_index, num_chunks) targets.
-
-    Input examples: 'double_blocks_0_img_attn_proj', 'single_blocks_5_linear1'
-    """
-    targets = []
-
+def _kohya_to_diffusers_targets(stripped):
+    """For kohya keys like ``double_blocks_0_img_attn_proj`` or ``single_blocks_5_linear1``."""
+    targets: list[tuple[str, int | None, int | None]] = []
     if stripped.startswith('single_blocks_'):
         rest = stripped[len('single_blocks_'):]
         idx, _, suffix = rest.partition('_')
         if suffix in F2_SINGLE_MAP:
             targets.append((f'single_transformer_blocks.{idx}.{F2_SINGLE_MAP[suffix]}', None, None))
-
     elif stripped.startswith('double_blocks_'):
         rest = stripped[len('double_blocks_'):]
         idx, _, kohya_suffix = rest.partition('_')
@@ -268,46 +257,131 @@ def _kohya_key_to_targets(stripped):
             attn_prefix, proj_keys = F2_QKV_MAP[bfl_suffix]
             for i, proj_key in enumerate(proj_keys):
                 targets.append((f'transformer_blocks.{idx}.{attn_prefix}.{proj_key}', i, len(proj_keys)))
-
     return targets
 
 
-def _bfl_key_to_targets(base):
-    """Map a BFL dot-separated key to (diffusers_module_path, chunk_index, num_chunks) targets.
-
-    Input examples: 'double_blocks.0.img_attn.proj', 'single_blocks.5.linear1'
-    Same mapping as LoKR uses.
-    """
-    targets = []
+def _bfl_to_diffusers_targets(base):
+    """For BFL keys like ``double_blocks.0.img_attn.proj`` or ``single_blocks.5.linear1``."""
+    targets: list[tuple[str, int | None, int | None]] = []
     parts = base.split('.')
     if len(parts) < 3:
         return targets
-
     block_type, block_idx, module_suffix = parts[0], parts[1], '.'.join(parts[2:])
-
     if block_type == 'single_blocks' and module_suffix in F2_SINGLE_MAP:
-        path = f'single_transformer_blocks.{block_idx}.{F2_SINGLE_MAP[module_suffix]}'
-        targets.append((path, None, None))
+        targets.append((f'single_transformer_blocks.{block_idx}.{F2_SINGLE_MAP[module_suffix]}', None, None))
     elif block_type == 'double_blocks':
         if module_suffix in F2_DOUBLE_MAP:
-            path = f'transformer_blocks.{block_idx}.{F2_DOUBLE_MAP[module_suffix]}'
-            targets.append((path, None, None))
+            targets.append((f'transformer_blocks.{block_idx}.{F2_DOUBLE_MAP[module_suffix]}', None, None))
         elif module_suffix in F2_QKV_MAP:
             attn_prefix, proj_keys = F2_QKV_MAP[module_suffix]
             for i, proj_key in enumerate(proj_keys):
-                path = f'transformer_blocks.{block_idx}.{attn_prefix}.{proj_key}'
-                targets.append((path, i, len(proj_keys)))
-
+                targets.append((f'transformer_blocks.{block_idx}.{attn_prefix}.{proj_key}', i, len(proj_keys)))
     return targets
 
 
-def apply_lora_alphas(state_dict):
-    """Bake kohya-format .alpha scaling into lora_down weights and remove alpha keys.
+# === Native loaders ===
 
-    Diffusers' Flux2 converter only handles lora_A/lora_B (or lora_down/lora_up) keys.
-    Kohya-format LoRAs store per-layer alpha values as separate .alpha keys that the
-    converter doesn't consume, causing a ValueError on leftover keys. This matches the
-    approach used by _convert_kohya_flux_lora_to_diffusers for Flux 1.
+
+def try_load_lora(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein LoRA (plus DoRA via the universal ``finalize_updown`` hook) as native modules.
+
+    Handles kohya, AI-toolkit/BFL, diffusers PEFT, and bare-BFL key formats.
+    Fused QKV in double_blocks is split at load time by chunking the up-weight
+    along dim 0; the down-weight is shared across Q/K/V.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, LORA_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, LORA_SUFFIXES)
+
+    unmapped = 0
+    mismatch = 0
+    for (prefix, base), w in groups.items():
+        if 'lora_down.weight' not in w or 'lora_up.weight' not in w:
+            continue
+        for diffusers_path, chunk_idx, num_chunks in resolve_targets(prefix, base):
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+
+            if chunk_idx is not None:
+                chunks = torch.chunk(w['lora_up.weight'], num_chunks, dim=0)
+                target_w = dict(w)
+                target_w['lora_up.weight'] = chunks[chunk_idx].contiguous()
+            else:
+                target_w = w
+
+            if not shapes_match(sd_module, target_w['lora_down.weight'], target_w['lora_up.weight']):
+                log.warning(
+                    f'Network load: type=LoRA name="{name}" key={network_key}'
+                    f' lora={target_w["lora_down.weight"].shape[1]}x{target_w["lora_up.weight"].shape[0]}'
+                    f' module={getattr(sd_module, "weight", None).shape if hasattr(sd_module, "weight") else "?"}'
+                    f' shape mismatch'
+                )
+                mismatch += 1
+                continue
+
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=target_w, sd_module=sd_module)
+            net.modules[network_key] = network_lora.NetworkModuleLora(net, nw)
+
+    return finalize_network(net, name, 'LoRA', lora_scale, t0, unmapped=unmapped, mismatch=mismatch)
+
+
+def try_load_lokr(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein LoKR as native modules.
+
+    Stores only the compact LoKR factors (``w1``/``w2``) and computes
+    ``kron(w1, w2)`` on-the-fly during weight application. For fused QKV
+    targets in double_blocks, :class:`NetworkModuleLokrChunk` materializes the
+    full Kronecker product and returns the designated Q/K/V slice.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, LOKR_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, LOKR_SUFFIXES)
+
+    unmapped = 0
+    for (prefix, base), w in groups.items():
+        has_1 = "lokr_w1" in w or ("lokr_w1_a" in w and "lokr_w1_b" in w)
+        has_2 = "lokr_w2" in w or ("lokr_w2_a" in w and "lokr_w2_b" in w)
+        if not (has_1 and has_2):
+            continue
+        for diffusers_path, chunk_idx, num_chunks in resolve_targets(prefix, base):
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
+            if chunk_idx is not None:
+                net.modules[network_key] = network_lokr.NetworkModuleLokrChunk(net, nw, chunk_idx, num_chunks)
+            else:
+                net.modules[network_key] = network_lokr.NetworkModuleLokr(net, nw)
+
+    return finalize_network(net, name, 'LoKR', lora_scale, t0, unmapped=unmapped)
+
+
+# === Diffusers-PEFT path helpers (used when lora_force_diffusers is on) ===
+
+
+def apply_lora_alphas(state_dict):
+    """Bake kohya-format ``.alpha`` scaling into ``lora_down`` weights and remove alpha keys.
+
+    Diffusers' Flux2 converter only handles ``lora_A``/``lora_B`` (or
+    ``lora_down``/``lora_up``) keys. Kohya-format LoRAs store per-layer alpha
+    values as separate ``.alpha`` keys that the converter does not consume,
+    causing a ``ValueError`` on leftover keys. This matches the approach used
+    by ``_convert_kohya_flux_lora_to_diffusers`` for Flux 1.
     """
     alpha_keys = [k for k in state_dict if k.endswith('.alpha')]
     if not alpha_keys:
@@ -339,8 +413,8 @@ def apply_lora_alphas(state_dict):
 
 
 def preprocess_f2_keys(state_dict):
-    """Add 'diffusion_model.' prefix to bare BFL-format keys so
-    Flux2LoraLoaderMixin's format detection routes them to the converter."""
+    """Add ``diffusion_model.`` prefix to bare BFL-format keys so
+    ``Flux2LoraLoaderMixin``'s format detection routes them to the converter."""
     if any(k.startswith("diffusion_model.") or k.startswith("base_model.model.") for k in state_dict):
         return state_dict
     if any(k.startswith(p) for k in state_dict for p in BARE_FLUX_PREFIXES):
@@ -349,98 +423,16 @@ def preprocess_f2_keys(state_dict):
     return state_dict
 
 
-def try_load_lokr(name, network_on_disk, lora_scale):
-    """Try loading a Flux2/Klein LoRA as LoKR native modules.
-
-    Returns a Network with native modules if the state dict contains LoKR keys,
-    or None to fall through to the generic diffusers path.
-    """
-    t0 = time.time()
-    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
-    if not any('.lokr_w1' in k for k in state_dict):
-        return None
-    net = load_lokr_native(name, network_on_disk, state_dict)
-    if len(net.modules) == 0:
-        log.error(f'Network load: type=LoKR name="{name}" no modules matched')
-        return None
-    log.debug(f'Network load: type=LoKR name="{name}" native modules={len(net.modules)} scale={lora_scale}')
-    l.timer.activate += time.time() - t0
-    return net
-
-
-def load_lokr_native(name, network_on_disk, state_dict):
-    """Load Flux2 LoKR as native modules applied at inference time.
-
-    Stores only the compact LoKR factors (w1, w2) and computes kron(w1, w2)
-    on-the-fly during weight application. For fused QKV modules in double
-    blocks, NetworkModuleLokrChunk computes the full Kronecker product and
-    returns only its designated Q/K/V chunk, then frees the temporary.
-    """
-    prefix = "diffusion_model."
-    sd_model = getattr(shared.sd_model, "pipe", shared.sd_model)
-    lora_convert.assign_network_names_to_compvis_modules(sd_model)
-    net = network.Network(name, network_on_disk)
-    net.mtime = os.path.getmtime(network_on_disk.filename)
-
-    for key in list(state_dict.keys()):
-        if not key.endswith('.lokr_w1'):
-            continue
-        if not key.startswith(prefix):
-            continue
-
-        base = key[len(prefix):].rsplit('.lokr_w1', 1)[0]
-        lokr_weights = {}
-        for suffix in ['lokr_w1', 'lokr_w2', 'lokr_w1_a', 'lokr_w1_b', 'lokr_w2_a', 'lokr_w2_b', 'lokr_t2', 'alpha']:
-            full_key = f'{prefix}{base}.{suffix}'
-            if full_key in state_dict:
-                lokr_weights[suffix] = state_dict[full_key]
-
-        parts = base.split('.')
-        block_type, block_idx, module_suffix = parts[0], parts[1], '.'.join(parts[2:])
-
-        targets = []  # (module_path, chunk_index, num_chunks)
-        if block_type == 'single_blocks' and module_suffix in F2_SINGLE_MAP:
-            path = f'single_transformer_blocks.{block_idx}.{F2_SINGLE_MAP[module_suffix]}'
-            targets.append((path, None, None))
-        elif block_type == 'double_blocks':
-            if module_suffix in F2_DOUBLE_MAP:
-                path = f'transformer_blocks.{block_idx}.{F2_DOUBLE_MAP[module_suffix]}'
-                targets.append((path, None, None))
-            elif module_suffix in F2_QKV_MAP:
-                attn_prefix, proj_keys = F2_QKV_MAP[module_suffix]
-                for i, proj_key in enumerate(proj_keys):
-                    path = f'transformer_blocks.{block_idx}.{attn_prefix}.{proj_key}'
-                    targets.append((path, i, len(proj_keys)))
-
-        for module_path, chunk_index, num_chunks in targets:
-            network_key = "lora_transformer_" + module_path.replace(".", "_")
-            sd_module = sd_model.network_layer_mapping.get(network_key)
-            if sd_module is None:
-                log.warning(f'Network load: type=LoKR module not found in mapping: {network_key}')
-                continue
-            weights = network.NetworkWeights(
-                network_key=network_key,
-                sd_key=network_key,
-                w=dict(lokr_weights),
-                sd_module=sd_module,
-            )
-            if chunk_index is not None:
-                net.modules[network_key] = network_lokr.NetworkModuleLokrChunk(net, weights, chunk_index, num_chunks)
-            else:
-                net.modules[network_key] = network_lokr.NetworkModuleLokr(net, weights)
-
-    return net
-
-
 patched = False
 
 
 def apply_patch():
-    """Patch Flux2LoraLoaderMixin.lora_state_dict to handle bare BFL-format keys.
+    """Patch ``Flux2LoraLoaderMixin.lora_state_dict`` to handle bare BFL-format keys.
 
-    When a LoRA file has bare BFL keys (no diffusion_model. prefix), the original
-    lora_state_dict won't detect them as AI toolkit format. This patch checks for
-    bare keys after the original returns and adds the prefix + re-runs conversion.
+    When a LoRA file has bare BFL keys (no ``diffusion_model.`` prefix), the
+    original ``lora_state_dict`` won't detect them as AI toolkit format. This
+    patch checks for bare keys after the original returns and adds the prefix +
+    re-runs conversion. Used only on the diffusers-PEFT fallback path.
     """
     global patched # pylint: disable=global-statement
     if patched:

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -38,7 +38,7 @@ import time
 import torch
 from modules import shared, sd_models
 from modules.logger import log
-from modules.lora import network, network_lora, network_lokr, network_hada, lora_convert
+from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, lora_convert
 from modules.lora import lora_common as l
 
 
@@ -78,10 +78,15 @@ LOHA_SUFFIXES = (
     ".hada_t1",   ".hada_t2",
     ".alpha", ".dora_scale", ".bias", ".scale",
 )
+OFT_SUFFIXES = (
+    ".oft_blocks", ".oft_diag",
+    ".alpha", ".dora_scale", ".bias", ".scale",
+)
 
 LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
 LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
 LOHA_MARKERS = (".hada_w1_a", ".hada_w1_b", ".hada_w2_a", ".hada_w2_b")
+OFT_MARKERS = (".oft_blocks", ".oft_diag")
 
 
 # === BFL → diffusers mapping ===
@@ -422,6 +427,48 @@ def try_load_loha(name, network_on_disk, lora_scale):
                 net.modules[network_key] = network_hada.NetworkModuleHada(net, nw)
 
     return finalize_network(net, name, 'LoHA', lora_scale, t0, unmapped=unmapped, skipped=skipped)
+
+
+def try_load_oft(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein OFT (Orthogonal Fine-Tuning) adapter as native modules.
+
+    Both kohya (``oft_blocks`` + alpha-as-constraint) and LyCORIS
+    (``oft_diag``) layouts are recognized via :class:`NetworkModuleOFT`.
+    Fused QKV in double_blocks is skipped with a warning: an OFT block
+    structure is tied to the target module's ``out_features``, so a per-Q/K/V
+    split would require re-deriving the rotation per chunk and is not a
+    drop-in. Single-block linear1 (a single fused diffusers module) and all
+    non-QKV double-block targets work fully.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, OFT_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, OFT_SUFFIXES)
+
+    unmapped = 0
+    skipped = 0
+    for (prefix, base), w in groups.items():
+        if not ('oft_blocks' in w or 'oft_diag' in w):
+            continue
+        targets = resolve_targets(prefix, base)
+        if any(t[1] is not None for t in targets):
+            log.warning(f'Network load: type=OFT name="{name}" key={base} fused QKV skipped (unsupported)')
+            skipped += 1
+            continue
+        for diffusers_path, _, _ in targets:
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
+            net.modules[network_key] = network_oft.NetworkModuleOFT(net, nw)
+
+    return finalize_network(net, name, 'OFT', lora_scale, t0, unmapped=unmapped, skipped=skipped)
 
 
 # === Diffusers-PEFT path helpers (used when lora_force_diffusers is on) ===

--- a/pipelines/flux/flux2_lora.py
+++ b/pipelines/flux/flux2_lora.py
@@ -38,7 +38,7 @@ import time
 import torch
 from modules import shared, sd_models
 from modules.logger import log
-from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, network_ia3, network_glora, lora_convert
+from modules.lora import network, network_lora, network_lokr, network_hada, network_oft, network_ia3, network_glora, network_norm, lora_convert
 from modules.lora import lora_common as l
 
 
@@ -91,6 +91,10 @@ GLORA_SUFFIXES = (
     ".b1.weight", ".b2.weight",
     ".alpha", ".dora_scale", ".scale",
 )
+NORM_SUFFIXES = (
+    ".w_norm", ".b_norm",
+    ".alpha", ".scale",
+)
 
 LORA_MARKERS = (".lora_down.weight", ".lora_up.weight", ".lora_A.weight", ".lora_B.weight")
 LOKR_MARKERS = (".lokr_w1", ".lokr_w2")
@@ -98,6 +102,7 @@ LOHA_MARKERS = (".hada_w1_a", ".hada_w1_b", ".hada_w2_a", ".hada_w2_b")
 OFT_MARKERS = (".oft_blocks", ".oft_diag")
 IA3_MARKERS = (".on_input",)  # NOT .weight — too generic, overlaps every other family
 GLORA_MARKERS = (".a1.weight", ".a2.weight", ".b1.weight", ".b2.weight")
+NORM_MARKERS = (".w_norm",)
 
 
 # === BFL → diffusers mapping ===
@@ -571,6 +576,64 @@ def try_load_glora(name, network_on_disk, lora_scale):
             net.modules[network_key] = network_glora.NetworkModuleGLora(net, nw)
 
     return finalize_network(net, name, 'GLoRA', lora_scale, t0, unmapped=unmapped, skipped=skipped)
+
+
+def try_load_norm(name, network_on_disk, lora_scale):
+    """Load a Flux2/Klein Norm adapter (LayerNorm/RMSNorm weight + bias deltas) as native modules.
+
+    Norm adapters target the RMSNorm modules inside Flux2 attention
+    (``attn.norm_q``, ``attn.norm_k``, ``attn.norm_added_q``,
+    ``attn.norm_added_k``) — the only norm modules in Flux2 with trainable
+    weights. The block-level ``norm1``/``norm2`` LayerNorms have
+    ``elementwise_affine=False`` and are not adaptable.
+
+    Loader-local stamping: ``modules/lora/lora_convert.py:assign_network_names_to_compvis_modules``
+    deliberately skips setting ``module.network_layer_name`` for transformer
+    norm modules (except SD3) because of legacy CompVis UNet collisions. This
+    loader bypasses the guard locally — for each target it actually binds, it
+    sets ``network_layer_name`` directly on the host module so
+    ``network_activate`` will apply the delta. No edit to the shared
+    ``lora_convert`` carve-out is required, and no norm module is touched
+    unless a Norm adapter explicitly targets it.
+
+    BFL/kohya prefix support is deferred — there is no public Flux2 BFL norm
+    mapping table to verify against. PEFT prefix (the format produced by
+    ``peft`` training) works directly because the base path is already a
+    diffusers path.
+    """
+    t0 = time.time()
+    state_dict = sd_models.read_state_dict(network_on_disk.filename, what='network')
+    if not has_marker(state_dict, NORM_MARKERS):
+        return None
+
+    mapping = resolve_mapping()
+    net = new_network(name, network_on_disk)
+    groups = group_by_suffixes(state_dict, NORM_SUFFIXES)
+
+    unmapped = 0
+    for (prefix, base), w in groups.items():
+        if 'w_norm' not in w:
+            continue
+        targets = resolve_targets(prefix, base)
+        if not targets:
+            unmapped += 1
+            continue
+        for diffusers_path, chunk_idx, _ in targets:
+            if chunk_idx is not None:
+                continue  # norm targets are not fused
+            network_key = "lora_transformer_" + diffusers_path.replace(".", "_")
+            sd_module = mapping.get(network_key)
+            if sd_module is None:
+                unmapped += 1
+                continue
+            # Bypass the lora_convert.py:502 transformer-norm guard locally.
+            # Stamping is idempotent and only touches modules a Norm adapter targets.
+            if not getattr(sd_module, 'network_layer_name', None):
+                sd_module.network_layer_name = network_key
+            nw = network.NetworkWeights(network_key=network_key, sd_key=network_key, w=w, sd_module=sd_module)
+            net.modules[network_key] = network_norm.NetworkModuleNorm(net, nw)
+
+    return finalize_network(net, name, 'Norm', lora_scale, t0, unmapped=unmapped)
 
 
 # === Diffusers-PEFT path helpers (used when lora_force_diffusers is on) ===

--- a/test/test-flux2-native-adapters.py
+++ b/test/test-flux2-native-adapters.py
@@ -1,0 +1,1268 @@
+#!/usr/bin/env python
+"""
+Offline unit tests for Flux2/Klein native adapter loaders.
+
+Covers the nine native families (LoRA, LoKR, LoHA, OFT, BOFT, IA3,
+GLoRA, Norm, Full) plus DoRA threading via the universal
+NetworkModule.finalize_updown hook, and ex_bias accumulation across
+stacked Norm adapters.
+
+The tests build a mock Flux2-shaped transformer, write synthetic
+safetensors files for each adapter format, and exercise the full loader
+path: state-dict -> group_by_suffixes -> resolve_targets ->
+NetworkModule* -> calc_updown -> finalize_updown.
+
+Loader correctness is verified against the documented LyCORIS / kohya
+save formats. End-to-end inference verification against real adapter
+files remains an open gap for the rarer families.
+
+No running server required.
+
+Usage:
+    python test/test-flux2-native-adapters.py
+"""
+
+import os
+import sys
+import tempfile
+import time
+
+import torch
+import safetensors.torch
+
+script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, script_dir)
+os.chdir(script_dir)
+
+os.environ['SD_INSTALL_QUIET'] = '1'
+
+# Bootstrap cmd_args before any module that pulls in shared.py.
+# parse_args() registers the full main+compat option set; installer.add_args
+# adds the installer-specific options on top.
+import modules.cmd_args  # pylint: disable=wrong-import-position
+import installer  # pylint: disable=wrong-import-position
+_orig_argv = sys.argv
+sys.argv = [sys.argv[0]]
+try:
+    modules.cmd_args.parse_args()
+finally:
+    sys.argv = _orig_argv
+installer.add_args(modules.cmd_args.parser)
+modules.cmd_args.parsed, _ = modules.cmd_args.parser.parse_known_args([])
+
+from modules.errors import log   # pylint: disable=wrong-import-position
+from modules import shared        # pylint: disable=wrong-import-position
+from modules.lora import (         # pylint: disable=wrong-import-position
+    network, network_lora, network_lokr, network_hada, network_oft, network_boft,
+    network_ia3, network_glora, network_norm, network_full,
+)
+from modules.lora import lora_apply   # pylint: disable=wrong-import-position
+from modules.lora import lora_common as l_common   # pylint: disable=wrong-import-position
+from pipelines.flux import flux2_lora as F         # pylint: disable=wrong-import-position
+
+
+# ============================================================
+# Test infrastructure
+# ============================================================
+
+results: dict[str, dict] = {}
+
+
+def category(name: str):
+    if name not in results:
+        results[name] = {'passed': 0, 'failed': 0, 'tests': []}
+    return name
+
+
+def record(cat: str, passed: bool, name: str, detail: str = ''):
+    status = 'PASS' if passed else 'FAIL'
+    results[cat]['passed' if passed else 'failed'] += 1
+    results[cat]['tests'].append((status, name))
+    msg = f'  {status}: {name}'
+    if detail:
+        msg += f' ({detail})'
+    if passed:
+        log.info(msg)
+    else:
+        log.error(msg)
+
+
+def run_test(cat: str, fn):
+    name = fn.__name__
+    try:
+        ok = fn()
+        if ok is False:
+            record(cat, False, name)
+        else:
+            record(cat, True, name)
+    except AssertionError as e:
+        record(cat, False, name, str(e))
+    except Exception as e:  # pylint: disable=broad-except
+        record(cat, False, name, f'exception: {e}')
+        import traceback
+        traceback.print_exc()
+
+
+# ============================================================
+# Mock Flux2-shaped transformer
+# ============================================================
+
+# Small but realistic shapes so tests are fast.
+HIDDEN = 128
+QKV_OUT = 128
+MLP_OUT = 512
+HEAD_DIM = 32
+SINGLE_FUSED_OUT = 3 * QKV_OUT + MLP_OUT  # to_qkv_mlp_proj
+SINGLE_OUT_IN = QKV_OUT + MLP_OUT          # to_out
+N_DOUBLE = 2
+N_SINGLE = 2
+
+
+# pylint: disable=attribute-defined-outside-init
+# `_Holder` is a generic container we attach diffusers-shaped children to at
+# runtime to mirror Flux2's transformer module tree.
+class _Holder(torch.nn.Module):
+    """Empty container module — we attach Linear/RMSNorm children dynamically."""
+
+
+def build_mock_transformer():
+    """Build a torch.nn.Module mimicking Flux2's diffusers-side module tree.
+
+    Mirrors the paths in F2_SINGLE_MAP / F2_DOUBLE_MAP / F2_QKV_MAP plus the
+    RMSNorm targets inside attention so that try_load_norm has something to
+    bind. Sizes are scaled-down but proportional so chunking math is realistic.
+    """
+    transformer = _Holder()
+    transformer.transformer_blocks = torch.nn.ModuleList()
+    for _ in range(N_DOUBLE):
+        block = _Holder()
+        block.attn = _Holder()
+        block.attn.to_q = torch.nn.Linear(HIDDEN, QKV_OUT, bias=False)
+        block.attn.to_k = torch.nn.Linear(HIDDEN, QKV_OUT, bias=False)
+        block.attn.to_v = torch.nn.Linear(HIDDEN, QKV_OUT, bias=False)
+        block.attn.to_out = torch.nn.ModuleList([torch.nn.Linear(QKV_OUT, HIDDEN, bias=False)])
+        block.attn.add_q_proj = torch.nn.Linear(HIDDEN, QKV_OUT, bias=False)
+        block.attn.add_k_proj = torch.nn.Linear(HIDDEN, QKV_OUT, bias=False)
+        block.attn.add_v_proj = torch.nn.Linear(HIDDEN, QKV_OUT, bias=False)
+        block.attn.to_add_out = torch.nn.Linear(QKV_OUT, HIDDEN, bias=False)
+        block.attn.norm_q = torch.nn.RMSNorm(HEAD_DIM)
+        block.attn.norm_k = torch.nn.RMSNorm(HEAD_DIM)
+        block.attn.norm_added_q = torch.nn.RMSNorm(HEAD_DIM)
+        block.attn.norm_added_k = torch.nn.RMSNorm(HEAD_DIM)
+        block.ff = _Holder()
+        block.ff.linear_in = torch.nn.Linear(HIDDEN, MLP_OUT, bias=False)
+        block.ff.linear_out = torch.nn.Linear(MLP_OUT, HIDDEN, bias=False)
+        block.ff_context = _Holder()
+        block.ff_context.linear_in = torch.nn.Linear(HIDDEN, MLP_OUT, bias=False)
+        block.ff_context.linear_out = torch.nn.Linear(MLP_OUT, HIDDEN, bias=False)
+        transformer.transformer_blocks.append(block)
+    transformer.single_transformer_blocks = torch.nn.ModuleList()
+    for _ in range(N_SINGLE):
+        sblock = _Holder()
+        sblock.attn = _Holder()
+        sblock.attn.to_qkv_mlp_proj = torch.nn.Linear(HIDDEN, SINGLE_FUSED_OUT, bias=False)
+        sblock.attn.to_out = torch.nn.Linear(SINGLE_OUT_IN, HIDDEN, bias=False)
+        transformer.single_transformer_blocks.append(sblock)
+    return transformer
+
+
+class _MockFlux2Pipeline:
+    """Class name carries 'Flux2' so shared.sd_model_type returns 'f2'
+    via modeldata.get_model_type's name-based dispatch."""
+
+    def __init__(self, transformer):
+        self.transformer = transformer
+        self.text_encoder = None
+
+
+class _MockFlux2SdModel:
+    """Outer wrapper holding the pipe + the network_layer_mapping that
+    lora_convert.assign_network_names_to_compvis_modules writes onto."""
+
+    def __init__(self, pipe):
+        self.pipe = pipe
+        self.network_layer_mapping = {}
+        self.embedding_db = None
+        self.__class__.__name__ = 'Flux2Pipeline'  # belt-and-suspenders
+
+
+def install_mock_pipe():
+    """Set shared.sd_model to a mock exposing a Flux2-shaped transformer.
+
+    Each test calls this fresh so module.network_layer_name stamps from prior
+    tests don't leak (notably the loader-local stamping in try_load_norm).
+
+    Bypasses the ModelData lock by writing directly to model_data.sd_model;
+    shared.sd_model = ... goes through set_sd_model which is a no-op when
+    model_data.locked is True (the default outside webui startup).
+    """
+    transformer = build_mock_transformer()
+    pipe = _MockFlux2Pipeline(transformer)
+    sd_model = _MockFlux2SdModel(pipe)
+    from modules.modeldata import model_data
+    model_data.sd_model = sd_model
+    return sd_model
+
+
+# ============================================================
+# State-dict synthesizers (one per family)
+# ============================================================
+
+# Realistic ranks for the synthesized factors.
+RANK_LORA = 8
+RANK_LOKR = 4
+LOKR_W1_DIM = 8
+LOKR_W2_DIM = HIDDEN // LOKR_W1_DIM
+
+
+def sd_lora_kohya_qkv():
+    """Kohya-format LoRA targeting fused img_attn.qkv (3-way chunked at load)."""
+    return {
+        # Down weight is shared across Q/K/V; up weight is fused (3*QKV_OUT, RANK).
+        'lora_unet_double_blocks_0_img_attn_qkv.lora_down.weight': torch.randn(RANK_LORA, HIDDEN),
+        'lora_unet_double_blocks_0_img_attn_qkv.lora_up.weight':   torch.randn(3 * QKV_OUT, RANK_LORA),
+        'lora_unet_double_blocks_0_img_attn_qkv.alpha':            torch.tensor(float(RANK_LORA)),
+    }
+
+
+def sd_lora_bfl_proj():
+    """BFL/AI-toolkit-format LoRA on a non-fused double_blocks proj target."""
+    return {
+        'diffusion_model.double_blocks.1.img_attn.proj.lora_A.weight': torch.randn(RANK_LORA, QKV_OUT),
+        'diffusion_model.double_blocks.1.img_attn.proj.lora_B.weight': torch.randn(HIDDEN, RANK_LORA),
+        'diffusion_model.double_blocks.1.img_attn.proj.alpha':         torch.tensor(float(RANK_LORA)),
+    }
+
+
+def sd_lora_peft_to_q():
+    """Diffusers PEFT-format LoRA targeting a single split-QKV diffusers path."""
+    return {
+        'transformer.transformer_blocks.0.attn.to_q.lora_A.weight': torch.randn(RANK_LORA, HIDDEN),
+        'transformer.transformer_blocks.0.attn.to_q.lora_B.weight': torch.randn(QKV_OUT, RANK_LORA),
+    }
+
+
+def sd_lora_bare_bfl_mlp():
+    """Bare BFL keys (no prefix) on an MLP target — exercises the bare fallback."""
+    return {
+        'double_blocks.0.img_mlp.0.lora_A.weight': torch.randn(RANK_LORA, HIDDEN),
+        'double_blocks.0.img_mlp.0.lora_B.weight': torch.randn(MLP_OUT, RANK_LORA),
+    }
+
+
+def sd_lora_peft_saved_fal_style():
+    """PEFT-saved LoRA: base_model.model. wrapper around BFL paths.
+
+    Mirrors the actual key layout of fal/flux-2-klein-4B-outpaint-lora as
+    inspected from its safetensors header on HF — first 12 keys all of the
+    form ``base_model.model.double_blocks.0.img_attn.proj.lora_A.weight``.
+    """
+    return {
+        'base_model.model.double_blocks.1.img_attn.proj.lora_A.weight': torch.randn(RANK_LORA, QKV_OUT),
+        'base_model.model.double_blocks.1.img_attn.proj.lora_B.weight': torch.randn(HIDDEN, RANK_LORA),
+        'base_model.model.double_blocks.1.img_attn.proj.alpha':         torch.tensor(float(RANK_LORA)),
+    }
+
+
+def sd_lora_peft_saved_dreambooth_style():
+    """PEFT-saved LoRA where the wrapped path is diffusers-form (HF DreamBooth).
+
+    HF DreamBooth scripts target diffusers modules by name (e.g.
+    ``transformer.transformer_blocks.0.attn.to_q``); after peft.save_pretrained
+    wraps the in-memory keys, the saved form is
+    ``base_model.model.transformer.transformer_blocks.0.attn.to_q.lora_A.weight``.
+    """
+    return {
+        'base_model.model.transformer.transformer_blocks.0.attn.to_q.lora_A.weight': torch.randn(RANK_LORA, HIDDEN),
+        'base_model.model.transformer.transformer_blocks.0.attn.to_q.lora_B.weight': torch.randn(QKV_OUT, RANK_LORA),
+    }
+
+
+def sd_lora_peft_saved_diffusers_style():
+    """PEFT-saved LoRA with bare-diffusers paths and a ``.default.`` adapter-name infix.
+
+    Mirrors the actual key layout of community Flux2 LoRAs exported via
+    ``Flux2Transformer2DModel.save_lora_adapter()`` after attaching an unnamed
+    PEFT adapter (e.g. ``lenovo_flux_klein9b.safetensors``):
+
+    - No ``transformer.`` / ``diffusion_model.`` / ``base_model.model.`` wrapper
+    - Keys start with bare ``transformer_blocks.`` or ``single_transformer_blocks.``
+    - ``.lora_A.default.weight`` / ``.lora_B.default.weight`` (PEFT adapter slot)
+    """
+    return {
+        # Single-block fused module — exercises the bare-diffusers prefix branch.
+        'single_transformer_blocks.0.attn.to_qkv_mlp_proj.lora_A.default.weight': torch.randn(RANK_LORA, HIDDEN),
+        'single_transformer_blocks.0.attn.to_qkv_mlp_proj.lora_B.default.weight': torch.randn(SINGLE_FUSED_OUT, RANK_LORA),
+        # Double-block split target — exercises both the bare-diffusers branch and the .default. strip.
+        'transformer_blocks.0.attn.to_q.lora_A.default.weight': torch.randn(RANK_LORA, HIDDEN),
+        'transformer_blocks.0.attn.to_q.lora_B.default.weight': torch.randn(QKV_OUT, RANK_LORA),
+    }
+
+
+def sd_lora_with_dora_scale():
+    """LoRA with a dora_scale companion vector — exercises DoRA threading."""
+    return {
+        'transformer.transformer_blocks.0.attn.to_q.lora_A.weight': torch.randn(RANK_LORA, HIDDEN),
+        'transformer.transformer_blocks.0.attn.to_q.lora_B.weight': torch.randn(QKV_OUT, RANK_LORA),
+        'transformer.transformer_blocks.0.attn.to_q.dora_scale':    torch.randn(QKV_OUT),
+    }
+
+
+def sd_lokr_bfl_proj():
+    """BFL-format LoKR on a non-fused proj target."""
+    return {
+        # w1 = (LOKR_W1_DIM, LOKR_W1_DIM), w2 = (LOKR_W2_DIM, LOKR_W2_DIM); kron is (HIDDEN, HIDDEN).
+        # Target shape is (HIDDEN, QKV_OUT) here; we need shape compat for calc_updown.
+        # Use w1=(QKV_OUT/LOKR_W2_DIM, HIDDEN/LOKR_W2_DIM) outer factor; LyCORIS picks dims by factorization.
+        'diffusion_model.double_blocks.1.img_attn.proj.lokr_w1': torch.randn(LOKR_W1_DIM, LOKR_W1_DIM),
+        'diffusion_model.double_blocks.1.img_attn.proj.lokr_w2': torch.randn(QKV_OUT // LOKR_W1_DIM, HIDDEN // LOKR_W1_DIM),
+        'diffusion_model.double_blocks.1.img_attn.proj.alpha':   torch.tensor(float(LOKR_W1_DIM)),
+    }
+
+
+def sd_lokr_kohya_qkv():
+    """Kohya LoKR targeting fused img_attn.qkv — exercises NetworkModuleLokrChunk."""
+    # Target after kron is (3*QKV_OUT, HIDDEN); chunk along dim=0 gives Q/K/V slices.
+    fused_out = 3 * QKV_OUT
+    # Pick w1=(8, ...) so kron of w1 with w2 spans fused_out x HIDDEN.
+    w1_dim_out = 8
+    w2_dim_out = fused_out // w1_dim_out
+    w1_dim_in = 4
+    w2_dim_in = HIDDEN // w1_dim_in
+    return {
+        'lora_unet_double_blocks_0_img_attn_qkv.lokr_w1': torch.randn(w1_dim_out, w1_dim_in),
+        'lora_unet_double_blocks_0_img_attn_qkv.lokr_w2': torch.randn(w2_dim_out, w2_dim_in),
+        'lora_unet_double_blocks_0_img_attn_qkv.alpha':   torch.tensor(float(w1_dim_in)),
+    }
+
+
+def sd_lokr_simpletuner_lycoris_style():
+    """LyCORIS-standalone-format LoKR (SimpleTuner save).
+
+    Mirrors the actual key layout of markury/flux2k9b-simpletuner-lokr-loona
+    as inspected from its safetensors header on HF — keys of the form
+    ``lycoris_transformer_blocks_0_attn_add_k_proj.lokr_w1`` (288 such keys
+    in the real file). The path under ``lycoris_`` is a diffusers path with
+    dots rendered as underscores; resolve_targets returns it verbatim and
+    the caller's ``.replace('.', '_')`` is a no-op.
+
+    Two targets here exercise both an img-side projection (to_q) and a
+    txt-side projection (add_k_proj) which uses underscores in the module
+    name itself — the latter is the case where naïve underscore-to-dot
+    expansion would corrupt the path.
+    """
+    return {
+        'lycoris_transformer_blocks_0_attn_to_q.lokr_w1':       torch.randn(LOKR_W1_DIM, LOKR_W1_DIM),
+        'lycoris_transformer_blocks_0_attn_to_q.lokr_w2':       torch.randn(QKV_OUT // LOKR_W1_DIM, HIDDEN // LOKR_W1_DIM),
+        'lycoris_transformer_blocks_0_attn_to_q.alpha':         torch.tensor(float(LOKR_W1_DIM)),
+        'lycoris_transformer_blocks_0_attn_add_k_proj.lokr_w1': torch.randn(LOKR_W1_DIM, LOKR_W1_DIM),
+        'lycoris_transformer_blocks_0_attn_add_k_proj.lokr_w2': torch.randn(QKV_OUT // LOKR_W1_DIM, HIDDEN // LOKR_W1_DIM),
+        'lycoris_transformer_blocks_0_attn_add_k_proj.alpha':   torch.tensor(float(LOKR_W1_DIM)),
+    }
+
+
+def sd_loha_bfl_proj():
+    """BFL-format LoHA on a non-fused proj target."""
+    return {
+        'diffusion_model.double_blocks.1.img_attn.proj.hada_w1_a': torch.randn(HIDDEN, RANK_LORA),
+        'diffusion_model.double_blocks.1.img_attn.proj.hada_w1_b': torch.randn(RANK_LORA, QKV_OUT),
+        'diffusion_model.double_blocks.1.img_attn.proj.hada_w2_a': torch.randn(HIDDEN, RANK_LORA),
+        'diffusion_model.double_blocks.1.img_attn.proj.hada_w2_b': torch.randn(RANK_LORA, QKV_OUT),
+        'diffusion_model.double_blocks.1.img_attn.proj.alpha':     torch.tensor(float(RANK_LORA)),
+    }
+
+
+def sd_loha_kohya_qkv():
+    """Kohya LoHA targeting fused img_attn.qkv — exercises NetworkModuleHadaChunk."""
+    fused_out = 3 * QKV_OUT
+    return {
+        'lora_unet_double_blocks_0_img_attn_qkv.hada_w1_a': torch.randn(fused_out, RANK_LORA),
+        'lora_unet_double_blocks_0_img_attn_qkv.hada_w1_b': torch.randn(RANK_LORA, HIDDEN),
+        'lora_unet_double_blocks_0_img_attn_qkv.hada_w2_a': torch.randn(fused_out, RANK_LORA),
+        'lora_unet_double_blocks_0_img_attn_qkv.hada_w2_b': torch.randn(RANK_LORA, HIDDEN),
+        'lora_unet_double_blocks_0_img_attn_qkv.alpha':     torch.tensor(float(RANK_LORA)),
+    }
+
+
+def sd_oft_kohya_proj():
+    """Kohya-format OFT (oft_blocks) on a non-fused proj target."""
+    # OFT block-diagonal: out_dim = HIDDEN, num_blocks=8, block_size=16.
+    return {
+        'lora_unet_double_blocks_1_img_attn_proj.oft_blocks': torch.zeros(8, 16, 16),
+        'lora_unet_double_blocks_1_img_attn_proj.alpha':      torch.tensor(1e-3),
+    }
+
+
+def sd_oft_lycoris_proj():
+    """LyCORIS-format OFT (oft_diag) — exercises the network_oft.py:58 NPE-fix path.
+
+    LyCORIS reads ``self.dim = oft_diag.shape[1]`` (the block_size) and computes
+    ``block_size, num_blocks = factorization(out_dim, dim)``. ``factorization``
+    always returns ``(smaller, larger)``. For out_dim=HIDDEN=128 with dim=8, it
+    returns (8, 16) ⇒ block_size=8, num_blocks=16. The tensor must therefore
+    have shape ``(num_blocks, block_size, block_size) = (16, 8, 8)``.
+    """
+    return {
+        'lora_unet_double_blocks_1_img_attn_proj.oft_diag': torch.zeros(16, 8, 8),
+    }
+
+
+def sd_oft_kohya_qkv_skipped():
+    """OFT on fused img_attn.qkv — must be skipped with a warning (no chunk class)."""
+    return {
+        'lora_unet_double_blocks_0_img_attn_qkv.oft_blocks': torch.zeros(8, 48, 48),
+        'lora_unet_double_blocks_0_img_attn_qkv.alpha':      torch.tensor(1e-3),
+    }
+
+
+def sd_boft_butterfly():
+    """BOFT (butterfly-OFT) — re-uses ``oft_blocks`` key with 4-D shape.
+
+    Mirrors the LyCORIS upstream save layout (boft.py weight_list:
+    ``oft_blocks, rescale, alpha``; tensor shape per __init__:
+    ``(boft_m, block_num, block_size, block_size)``).
+
+    For HIDDEN=128 with block_size=16, block_num=8:
+    - boft_m derives from sum-of-set-bits of (block_num-1) + 1 = bits(7)+1 = 4
+    - cascade indices: k = 2^i * r_b for i in 0..3, with r_b = 8
+    - all four stages divide cleanly into 128-row tensors
+    """
+    return {
+        'lora_unet_double_blocks_1_img_attn_proj.oft_blocks':
+            torch.randn(4, 8, 16, 16) * 0.01,
+        'lora_unet_double_blocks_1_img_attn_proj.alpha':
+            torch.tensor(1e-3),
+    }
+
+
+def sd_ia3_proj():
+    """IA3 on a non-fused target. on_input=False ⇒ output-axis scaling."""
+    return {
+        'lora_unet_double_blocks_1_img_attn_proj.weight':   torch.randn(HIDDEN),
+        'lora_unet_double_blocks_1_img_attn_proj.on_input': torch.tensor(0),
+    }
+
+
+def sd_ia3_qkv_skipped():
+    """IA3 on fused QKV — must be skipped with a warning."""
+    return {
+        'lora_unet_double_blocks_0_img_attn_qkv.weight':   torch.randn(3 * QKV_OUT),
+        'lora_unet_double_blocks_0_img_attn_qkv.on_input': torch.tensor(0),
+    }
+
+
+def sd_glora_proj():
+    """GLoRA on a non-fused proj target.
+
+    Target host module is ``attn.to_out.0`` with weight shape (out, in)
+    = (HIDDEN, QKV_OUT). NetworkModuleGLora computes
+    ``updown = (w2b @ w1b) + ((target @ w2a) @ w1a)``, which needs:
+
+    - w2b: (out, rank), w1b: (rank, in)   ⇒ first term shape (out, in)
+    - w2a: (in, rank),  w1a: (rank, in)   ⇒ second term ((out,in) @ (in,rank)) @ (rank,in) = (out, in)
+    """
+    out_dim = HIDDEN
+    in_dim = QKV_OUT
+    return {
+        'lora_unet_double_blocks_1_img_attn_proj.a1.weight': torch.randn(RANK_LORA, in_dim),
+        'lora_unet_double_blocks_1_img_attn_proj.a2.weight': torch.randn(in_dim, RANK_LORA),
+        'lora_unet_double_blocks_1_img_attn_proj.b1.weight': torch.randn(RANK_LORA, in_dim),
+        'lora_unet_double_blocks_1_img_attn_proj.b2.weight': torch.randn(out_dim, RANK_LORA),
+        'lora_unet_double_blocks_1_img_attn_proj.alpha':     torch.tensor(float(RANK_LORA)),
+    }
+
+
+def sd_norm_peft_attn_norm_q():
+    """Norm targeting a real Flux2 RMSNorm (attn.norm_q)."""
+    return {
+        'transformer.transformer_blocks.0.attn.norm_q.w_norm': torch.randn(HEAD_DIM) * 0.01,
+        'transformer.transformer_blocks.0.attn.norm_q.b_norm': torch.randn(HEAD_DIM) * 0.01,
+    }
+
+
+def sd_full_proj():
+    """Full-rank delta on a proj target. diff matches host weight shape (out, in)."""
+    return {
+        'lora_unet_double_blocks_1_img_attn_proj.diff':   torch.randn(HIDDEN, QKV_OUT) * 0.01,
+        'lora_unet_double_blocks_1_img_attn_proj.diff_b': torch.randn(HIDDEN) * 0.01,
+    }
+
+
+# ============================================================
+# Test plumbing helpers
+# ============================================================
+
+class TempLora:
+    """Context-manager that materializes a synthetic state dict as a real
+    safetensors file and yields a NetworkOnDisk pointing at it.
+
+    Required because flux2_lora's loaders read via sd_models.read_state_dict,
+    which only accepts a filename. Cleans up the temp file on exit.
+    """
+
+    def __init__(self, state_dict, name='test'):
+        self.state_dict = state_dict
+        self.name = name
+        self.path = None
+
+    def __enter__(self):
+        fd, self.path = tempfile.mkstemp(suffix='.safetensors', prefix=f'{self.name}_')
+        os.close(fd)
+        # safetensors requires contiguous tensors.
+        sd = {k: v.contiguous() for k, v in self.state_dict.items()}
+        safetensors.torch.save_file(sd, self.path)
+        return _MockNetworkOnDisk(self.name, self.path)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.path and os.path.exists(self.path):
+            os.unlink(self.path)
+
+
+class _MockNetworkOnDisk:
+    """Minimal NetworkOnDisk shim — loaders only touch .filename, .name, .shorthash, .sd_version."""
+
+    def __init__(self, name, filename):
+        self.name = name
+        self.filename = filename
+        self.shorthash = ''
+        self.sd_version = 'f2'
+        self.metadata = {}
+
+    def read_hash(self):
+        pass
+
+
+def assert_shape(t: torch.Tensor, expected_shape, label=''):
+    actual = tuple(t.shape)
+    expected = tuple(expected_shape)
+    assert actual == expected, f'{label} shape {actual} != expected {expected}'
+
+
+def assert_finite(t: torch.Tensor, label=''):
+    assert torch.isfinite(t).all(), f'{label} contains non-finite values'
+
+
+def make_network_for_module(net_module: network.NetworkModule, te_mul: float = 1.0, unet_mul: float = 1.0):
+    """Wire a NetworkModule into a Network with given multipliers so calc_updown
+    has a meaningful multiplier()/calc_scale() context."""
+    net_module.network.te_multiplier = te_mul
+    net_module.network.unet_multiplier = unet_mul
+    return net_module
+
+
+# ============================================================
+# Tests — parsing primitives
+# ============================================================
+
+CAT_PARSE = category('parse')
+
+
+def test_parse_key_all_prefixes():
+    cases = [
+        ('lora_unet_double_blocks_0_img_attn_qkv.lora_down.weight',
+         F.LORA_SUFFIXES,
+         ('lora_unet_', 'double_blocks_0_img_attn_qkv', 'lora_down.weight')),
+        ('diffusion_model.double_blocks.0.img_attn.proj.lora_A.weight',
+         F.LORA_SUFFIXES,
+         ('diffusion_model.', 'double_blocks.0.img_attn.proj', 'lora_down.weight')),
+        ('transformer.transformer_blocks.0.attn.to_q.lora_B.weight',
+         F.LORA_SUFFIXES,
+         ('transformer.', 'transformer_blocks.0.attn.to_q', 'lora_up.weight')),
+        ('double_blocks.10.img_mlp.0.lora_A.weight',
+         F.LORA_SUFFIXES,
+         (None, 'double_blocks.10.img_mlp.0', 'lora_down.weight')),
+        ('random.unrelated.key', F.LORA_SUFFIXES, None),
+    ]
+    for key, suffixes, expected in cases:
+        got = F.parse_key(key, suffixes)
+        assert got == expected, f'parse_key({key!r}) = {got}, expected {expected}'
+    return True
+
+
+def test_resolve_targets_qkv_chunking():
+    # Kohya double_blocks fused QKV → three chunks targeting Q/K/V.
+    targets = F.resolve_targets('lora_unet_', 'double_blocks_0_img_attn_qkv')
+    assert targets == [
+        ('transformer_blocks.0.attn.to_q', 0, 3),
+        ('transformer_blocks.0.attn.to_k', 1, 3),
+        ('transformer_blocks.0.attn.to_v', 2, 3),
+    ], f'kohya img_attn.qkv → {targets}'
+
+    targets = F.resolve_targets('lora_unet_', 'double_blocks_5_txt_attn_qkv')
+    assert targets == [
+        ('transformer_blocks.5.attn.add_q_proj', 0, 3),
+        ('transformer_blocks.5.attn.add_k_proj', 1, 3),
+        ('transformer_blocks.5.attn.add_v_proj', 2, 3),
+    ], f'kohya txt_attn.qkv → {targets}'
+
+    targets = F.resolve_targets('diffusion_model.', 'single_blocks.7.linear1')
+    assert targets == [('single_transformer_blocks.7.attn.to_qkv_mlp_proj', None, None)]
+
+    targets = F.resolve_targets('transformer.', 'transformer_blocks.0.attn.to_q')
+    assert targets == [('transformer_blocks.0.attn.to_q', None, None)]
+
+    targets = F.resolve_targets('weird_prefix.', 'whatever')
+    assert targets == []
+    return True
+
+
+def test_parse_key_peft_wrapper_unwrap():
+    """base_model.model. wrapper is stripped before format detection.
+
+    Verifies the unwrap handles all four content cases:
+    - BFL keys under the wrapper (fal style)
+    - Diffusers paths under transformer. under the wrapper (HF DreamBooth style)
+    - Bare BFL under the wrapper
+    - Wrapper not present (passthrough)
+    """
+    cases = [
+        ('base_model.model.double_blocks.1.img_attn.proj.lora_A.weight',
+         F.LORA_SUFFIXES,
+         (None, 'double_blocks.1.img_attn.proj', 'lora_down.weight')),
+        ('base_model.model.transformer.transformer_blocks.0.attn.to_q.lora_A.weight',
+         F.LORA_SUFFIXES,
+         ('transformer.', 'transformer_blocks.0.attn.to_q', 'lora_down.weight')),
+        ('base_model.model.lora_unet_double_blocks_0_img_attn_proj.lora_down.weight',
+         F.LORA_SUFFIXES,
+         ('lora_unet_', 'double_blocks_0_img_attn_proj', 'lora_down.weight')),
+        ('diffusion_model.double_blocks.0.img_attn.proj.lora_A.weight',  # no wrapper
+         F.LORA_SUFFIXES,
+         ('diffusion_model.', 'double_blocks.0.img_attn.proj', 'lora_down.weight')),
+    ]
+    for key, suffixes, expected in cases:
+        got = F.parse_key(key, suffixes)
+        assert got == expected, f'parse_key({key!r}) = {got}, expected {expected}'
+    return True
+
+
+def test_parse_key_lycoris_prefix():
+    """lycoris_ prefix yields an underscored diffusers path; no _ -> . conversion."""
+    cases = [
+        ('lycoris_transformer_blocks_0_attn_to_q.lokr_w1',
+         F.LOKR_SUFFIXES,
+         ('lycoris_', 'transformer_blocks_0_attn_to_q', 'lokr_w1')),
+        ('lycoris_transformer_blocks_0_attn_add_k_proj.lokr_w2',
+         F.LOKR_SUFFIXES,
+         ('lycoris_', 'transformer_blocks_0_attn_add_k_proj', 'lokr_w2')),
+        ('lycoris_single_transformer_blocks_5_attn_to_qkv_mlp_proj.lokr_w1',
+         F.LOKR_SUFFIXES,
+         ('lycoris_', 'single_transformer_blocks_5_attn_to_qkv_mlp_proj', 'lokr_w1')),
+    ]
+    for key, suffixes, expected in cases:
+        got = F.parse_key(key, suffixes)
+        assert got == expected, f'parse_key({key!r}) = {got}, expected {expected}'
+
+    # resolve_targets: the underscored path is returned verbatim (no chunk).
+    targets = F.resolve_targets('lycoris_', 'transformer_blocks_0_attn_add_k_proj')
+    assert targets == [('transformer_blocks_0_attn_add_k_proj', None, None)], f'targets={targets}'
+    return True
+
+
+def test_parse_key_bare_diffusers_and_peft_default():
+    """Bare-diffusers paths + ``.lora_[AB].<adapter_name>.weight`` infix.
+
+    Covers ``Flux2Transformer2DModel.save_lora_adapter()`` output where the file
+    has no wrapping prefix and PEFT keeps the adapter slot name in the suffix.
+    """
+    bd = F.BARE_DIFFUSERS_PREFIX_USED
+    cases = [
+        ('single_transformer_blocks.0.attn.to_qkv_mlp_proj.lora_A.default.weight',
+         F.LORA_SUFFIXES,
+         (bd, 'single_transformer_blocks.0.attn.to_qkv_mlp_proj', 'lora_down.weight')),
+        ('transformer_blocks.0.attn.to_q.lora_B.default.weight',
+         F.LORA_SUFFIXES,
+         (bd, 'transformer_blocks.0.attn.to_q', 'lora_up.weight')),
+        # Non-default adapter name also strips.
+        ('transformer_blocks.7.attn.to_v.lora_A.style.weight',
+         F.LORA_SUFFIXES,
+         (bd, 'transformer_blocks.7.attn.to_v', 'lora_down.weight')),
+        # No adapter-name infix passes through unchanged.
+        ('transformer_blocks.0.attn.to_q.lora_A.weight',
+         F.LORA_SUFFIXES,
+         (bd, 'transformer_blocks.0.attn.to_q', 'lora_down.weight')),
+        # Wrapped path with adapter-name infix: unwrap + strip both apply.
+        ('base_model.model.transformer.transformer_blocks.0.attn.to_q.lora_A.default.weight',
+         F.LORA_SUFFIXES,
+         ('transformer.', 'transformer_blocks.0.attn.to_q', 'lora_down.weight')),
+    ]
+    for key, suffixes, expected in cases:
+        got = F.parse_key(key, suffixes)
+        assert got == expected, f'parse_key({key!r}) = {got}, expected {expected}'
+
+    # resolve_targets passes the bare-diffusers path through verbatim.
+    targets = F.resolve_targets(bd, 'single_transformer_blocks.5.attn.to_out')
+    assert targets == [('single_transformer_blocks.5.attn.to_out', None, None)], f'targets={targets}'
+    return True
+
+
+def test_marker_disambiguation():
+    # Each family's marker must reject other families' files.
+    pure_lora = {'lora_unet_x.lora_down.weight': torch.zeros(1, 1),
+                 'lora_unet_x.lora_up.weight':   torch.zeros(1, 1)}
+    assert F.has_marker(pure_lora, F.LORA_MARKERS)
+    assert not F.has_marker(pure_lora, F.LOKR_MARKERS)
+    assert not F.has_marker(pure_lora, F.LOHA_MARKERS)
+    assert not F.has_marker(pure_lora, F.OFT_MARKERS)
+    assert not F.has_marker(pure_lora, F.IA3_MARKERS)
+    assert not F.has_marker(pure_lora, F.GLORA_MARKERS)
+    assert not F.has_marker(pure_lora, F.NORM_MARKERS)
+    assert not F.has_marker(pure_lora, F.FULL_MARKERS)
+
+    ia3 = {'lora_unet_x.weight': torch.zeros(1), 'lora_unet_x.on_input': torch.tensor(1)}
+    assert F.has_marker(ia3, F.IA3_MARKERS)
+    # IA3 shares ".weight" but only on_input is the disambiguator.
+    return True
+
+
+# ============================================================
+# Tests — loaders (one per family)
+# ============================================================
+
+CAT_LOADER = category('loader')
+
+
+def _load_via(try_fn, state_dict, name='test'):
+    install_mock_pipe()
+    with TempLora(state_dict, name=name) as nod:
+        return try_fn(name, nod, lora_scale=1.0)
+
+
+def test_lora_kohya_fused_qkv_chunked():
+    net = _load_via(F.try_load_lora, sd_lora_kohya_qkv())
+    assert net is not None and len(net.modules) == 3, f'expected 3 chunked modules, got {net.modules if net else None}'
+    # Network keys correspond to the three split projections.
+    expected_keys = {
+        'lora_transformer_transformer_blocks_0_attn_to_q',
+        'lora_transformer_transformer_blocks_0_attn_to_k',
+        'lora_transformer_transformer_blocks_0_attn_to_v',
+    }
+    assert set(net.modules) == expected_keys, f'got {set(net.modules)}'
+    # Every module is a NetworkModuleLora; up-weight has been chunked along dim 0.
+    for nk, mod in net.modules.items():
+        assert isinstance(mod, network_lora.NetworkModuleLora), f'{nk}: type={type(mod).__name__}'
+        # The chunked up tensor has shape (QKV_OUT, RANK), not (3*QKV_OUT, RANK).
+        up_shape = tuple(mod.up_model.weight.shape)
+        assert up_shape == (QKV_OUT, RANK_LORA), f'{nk}: up shape {up_shape}'
+    return True
+
+
+def test_lora_bfl_non_fused():
+    net = _load_via(F.try_load_lora, sd_lora_bfl_proj())
+    assert net is not None and len(net.modules) == 1, f'got {net.modules if net else None}'
+    nk, mod = next(iter(net.modules.items()))
+    assert nk == 'lora_transformer_transformer_blocks_1_attn_to_out_0', f'{nk}'
+    assert isinstance(mod, network_lora.NetworkModuleLora)
+    return True
+
+
+def test_lora_peft_format():
+    net = _load_via(F.try_load_lora, sd_lora_peft_to_q())
+    assert net is not None and len(net.modules) == 1
+    assert 'lora_transformer_transformer_blocks_0_attn_to_q' in net.modules
+    return True
+
+
+def test_lora_bare_bfl_format():
+    net = _load_via(F.try_load_lora, sd_lora_bare_bfl_mlp())
+    assert net is not None and len(net.modules) == 1
+    assert 'lora_transformer_transformer_blocks_0_ff_linear_in' in net.modules
+    return True
+
+
+def test_lora_peft_saved_fal_style():
+    """Real-world PEFT-saved LoRA with BFL paths under base_model.model. wrapper."""
+    net = _load_via(F.try_load_lora, sd_lora_peft_saved_fal_style())
+    assert net is not None and len(net.modules) == 1, f'got {net.modules if net else None}'
+    # base_model.model.double_blocks.1.img_attn.proj → transformer_blocks.1.attn.to_out.0
+    assert 'lora_transformer_transformer_blocks_1_attn_to_out_0' in net.modules
+    return True
+
+
+def test_lora_peft_saved_dreambooth_style():
+    """PEFT-saved LoRA with diffusers paths under base_model.model. wrapper.
+
+    HF DreamBooth-style: the path under base_model.model. starts with
+    transformer., which the unwrap+reparse routes through the standard PEFT
+    branch. Verifies the unwrap handles nested format prefixes correctly.
+    """
+    net = _load_via(F.try_load_lora, sd_lora_peft_saved_dreambooth_style())
+    assert net is not None and len(net.modules) == 1
+    assert 'lora_transformer_transformer_blocks_0_attn_to_q' in net.modules
+    return True
+
+
+def test_lora_peft_saved_diffusers_style():
+    """Bare-diffusers paths + PEFT ``.default.`` adapter-name infix.
+
+    Exercises the bare-diffusers prefix branch (``single_transformer_blocks.``,
+    ``transformer_blocks.``) combined with the PEFT-saved ``.lora_A.default.weight``
+    suffix shape produced by ``Flux2Transformer2DModel.save_lora_adapter()``.
+    """
+    net = _load_via(F.try_load_lora, sd_lora_peft_saved_diffusers_style())
+    assert net is not None and len(net.modules) == 2, f'expected 2 modules, got {net.modules if net else None}'
+    assert 'lora_transformer_single_transformer_blocks_0_attn_to_qkv_mlp_proj' in net.modules
+    assert 'lora_transformer_transformer_blocks_0_attn_to_q' in net.modules
+    return True
+
+
+def test_lora_dora_threading():
+    net = _load_via(F.try_load_lora, sd_lora_with_dora_scale())
+    assert net is not None and len(net.modules) == 1
+    mod = next(iter(net.modules.values()))
+    assert mod.dora_scale is not None, 'dora_scale not threaded into NetworkModule'
+    # Apply path runs through finalize_updown which calls apply_weight_decompose.
+    target = torch.randn(QKV_OUT, HIDDEN)
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, (QKV_OUT, HIDDEN), 'DoRA updown')
+    assert_finite(updown, 'DoRA updown')
+    return True
+
+
+def test_lokr_bfl_non_fused():
+    net = _load_via(F.try_load_lokr, sd_lokr_bfl_proj())
+    assert net is not None and len(net.modules) == 1
+    nk, mod = next(iter(net.modules.items()))
+    assert isinstance(mod, network_lokr.NetworkModuleLokr) and not isinstance(mod, network_lokr.NetworkModuleLokrChunk), \
+        f'{nk}: type={type(mod).__name__}'
+    return True
+
+
+def test_lokr_kohya_fused_qkv_chunked():
+    net = _load_via(F.try_load_lokr, sd_lokr_kohya_qkv())
+    assert net is not None and len(net.modules) == 3
+    for nk, mod in net.modules.items():
+        assert isinstance(mod, network_lokr.NetworkModuleLokrChunk), f'{nk}: type={type(mod).__name__}'
+        assert 0 <= mod.chunk_index < 3 and mod.num_chunks == 3
+    return True
+
+
+def test_lokr_simpletuner_lycoris_format():
+    """Real-world LyCORIS-standalone LoKR with lycoris_ prefix on diffusers paths.
+
+    Critical case: one of the targets is ``add_k_proj`` whose Linear name has
+    embedded underscores. Confirms the loader does NOT do a naive _ -> .
+    expansion on the base path; the underscored form must round-trip through
+    the network_layer_mapping lookup intact.
+    """
+    net = _load_via(F.try_load_lokr, sd_lokr_simpletuner_lycoris_style())
+    assert net is not None and len(net.modules) == 2, f'got {net.modules if net else None}'
+    expected = {
+        'lora_transformer_transformer_blocks_0_attn_to_q',
+        'lora_transformer_transformer_blocks_0_attn_add_k_proj',
+    }
+    assert set(net.modules) == expected, f'got {set(net.modules)}'
+    for mod in net.modules.values():
+        assert isinstance(mod, network_lokr.NetworkModuleLokr)
+    return True
+
+
+def test_loha_bfl_non_fused():
+    net = _load_via(F.try_load_loha, sd_loha_bfl_proj())
+    assert net is not None and len(net.modules) == 1
+    nk, mod = next(iter(net.modules.items()))
+    assert isinstance(mod, network_hada.NetworkModuleHada) and not isinstance(mod, network_hada.NetworkModuleHadaChunk), \
+        f'{nk}: type={type(mod).__name__}'
+    return True
+
+
+def test_loha_kohya_fused_qkv_chunked():
+    net = _load_via(F.try_load_loha, sd_loha_kohya_qkv())
+    assert net is not None and len(net.modules) == 3
+    for nk, mod in net.modules.items():
+        assert isinstance(mod, network_hada.NetworkModuleHadaChunk), f'{nk}: type={type(mod).__name__}'
+        assert 0 <= mod.chunk_index < 3 and mod.num_chunks == 3
+    return True
+
+
+def test_oft_kohya_non_fused():
+    net = _load_via(F.try_load_oft, sd_oft_kohya_proj())
+    assert net is not None and len(net.modules) == 1
+    _, mod = next(iter(net.modules.items()))
+    assert isinstance(mod, network_oft.NetworkModuleOFT)
+    assert mod.is_kohya is True and mod.constraint is not None
+    return True
+
+
+def test_oft_lycoris_no_npe():
+    """LyCORIS OFT (oft_diag) loads and calc_updown completes without
+    accessing self.constraint, which is None in the LyCORIS path.
+    """
+    net = _load_via(F.try_load_oft, sd_oft_lycoris_proj())
+    assert net is not None and len(net.modules) == 1
+    _, mod = next(iter(net.modules.items()))
+    assert isinstance(mod, network_oft.NetworkModuleOFT)
+    assert mod.is_kohya is False and mod.constraint is None
+    target = mod.sd_module.weight  # real (HIDDEN, QKV_OUT) tensor from the mock
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape), 'LyCORIS OFT updown')
+    assert_finite(updown, 'LyCORIS OFT updown')
+    return True
+
+
+def test_oft_fused_qkv_skipped():
+    """OFT on fused QKV must be dropped (with warning) — no chunk class exists."""
+    net = _load_via(F.try_load_oft, sd_oft_kohya_qkv_skipped())
+    # Loader returns None when no modules bound (skipped + nothing else).
+    assert net is None or len(net.modules) == 0
+    return True
+
+
+def test_boft_loads_and_applies():
+    """BOFT files (4-D oft_blocks) bind to NetworkModuleBOFT via the
+    try_load_oft dispatch. Verifies shape attrs derive correctly from
+    the 4-D tensor and the butterfly-cascade calc_updown returns a
+    finite delta of host weight shape.
+    """
+    net = _load_via(F.try_load_oft, sd_boft_butterfly())
+    assert net is not None and len(net.modules) == 1, \
+        f'BOFT did not load (got {net.modules if net else None})'
+    mod = next(iter(net.modules.values()))
+    assert isinstance(mod, network_boft.NetworkModuleBOFT), \
+        f'expected NetworkModuleBOFT, got {type(mod).__name__}'
+    assert isinstance(mod, network_boft.NetworkModuleBOFT) and not isinstance(mod, network_oft.NetworkModuleOFT), \
+        'BOFT must not be a subclass of NetworkModuleOFT (separate algorithm)'
+    # BOFT-specific shape attributes resolved correctly
+    assert mod.boft_m == 4 and mod.block_num == 8 and mod.block_size == 16, \
+        f'shape attrs: boft_m={mod.boft_m} block_num={mod.block_num} block_size={mod.block_size}'
+    # End-to-end calc_updown via the butterfly cascade
+    target = mod.sd_module.weight  # (HIDDEN=128, QKV_OUT=128) for to_out.0
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape), 'BOFT updown')
+    assert_finite(updown, 'BOFT updown')
+    return True
+
+
+def test_ia3_basic_load():
+    net = _load_via(F.try_load_ia3, sd_ia3_proj())
+    assert net is not None and len(net.modules) == 1
+    _, mod = next(iter(net.modules.items()))
+    assert isinstance(mod, network_ia3.NetworkModuleIa3)
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape), 'IA3 updown')
+    return True
+
+
+def test_ia3_fused_qkv_skipped():
+    net = _load_via(F.try_load_ia3, sd_ia3_qkv_skipped())
+    assert net is None or len(net.modules) == 0
+    return True
+
+
+def test_glora_basic_load_and_alpha():
+    """GLoRA loads, self.dim is populated from w1b.shape[0], and
+    calc_scale returns alpha/dim rather than the 1.0 fallback.
+    """
+    state_dict = sd_glora_proj()
+    net = _load_via(F.try_load_glora, state_dict)
+    assert net is not None and len(net.modules) == 1
+    mod = next(iter(net.modules.values()))
+    assert isinstance(mod, network_glora.NetworkModuleGLora)
+    assert mod.dim is not None, 'GLoRA dim not set (regression)'
+    expected_dim = state_dict['lora_unet_double_blocks_1_img_attn_proj.b1.weight'].shape[0]
+    assert mod.dim == expected_dim, f'GLoRA dim {mod.dim} != {expected_dim}'
+    # alpha=RANK_LORA (8), dim=expected_dim (8) → calc_scale = 1.0; instructive but matches kohya convention.
+    expected_alpha = float(RANK_LORA)
+    assert mod.alpha == expected_alpha, f'alpha={mod.alpha}'
+    expected_scale = expected_alpha / expected_dim
+    actual_scale = mod.calc_scale()
+    assert abs(actual_scale - expected_scale) < 1e-6, f'calc_scale={actual_scale} expected {expected_scale} (alpha/dim)'
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape), 'GLoRA updown')
+    assert_finite(updown, 'GLoRA updown')
+    return True
+
+
+def test_norm_loader_local_stamping():
+    """Regression for the loader-local stamping behavior in try_load_norm.
+
+    lora_convert.assign_network_names_to_compvis_modules deliberately skips
+    setting module.network_layer_name on transformer norm modules. The Norm
+    loader must stamp them itself for any module it actually binds, so the
+    activation loop (which checks network_layer_name is not None) can apply
+    the delta. Verify both: pre-loader the norm module has no
+    network_layer_name; post-loader the bound target does.
+    """
+    sd_model = install_mock_pipe()
+    norm_module = sd_model.pipe.transformer.transformer_blocks[0].attn.norm_q
+    assert not getattr(norm_module, 'network_layer_name', None), \
+        'mock norm should not have network_layer_name pre-load'
+    # First call assign_network_names manually to mirror what resolve_mapping does.
+    from modules.lora import lora_convert
+    lora_convert.assign_network_names_to_compvis_modules(sd_model.pipe)
+    # The carve-out skipped stamping for norm modules.
+    assert not getattr(norm_module, 'network_layer_name', None), \
+        'norm module should still be unstamped after assign_network_names (lora_convert.py:502 carve-out)'
+    # Now run the loader.
+    state_dict = sd_norm_peft_attn_norm_q()
+    with TempLora(state_dict, name='norm_test') as nod:
+        net = F.try_load_norm('norm_test', nod, lora_scale=1.0)
+    assert net is not None and len(net.modules) == 1, 'Norm loader produced no modules'
+    mod = next(iter(net.modules.values()))
+    assert isinstance(mod, network_norm.NetworkModuleNorm)
+    # Loader-local stamping: the bound module now has network_layer_name set.
+    assert getattr(norm_module, 'network_layer_name', None) == 'lora_transformer_transformer_blocks_0_attn_norm_q', \
+        f'Norm loader did not stamp network_layer_name (got {getattr(norm_module, "network_layer_name", None)!r})'
+    # calc_updown returns updown + ex_bias for w_norm + b_norm.
+    target = norm_module.weight
+    updown, ex_bias = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape), 'Norm updown')
+    assert ex_bias is not None, 'Norm ex_bias should be present when b_norm is set'
+    assert_shape(ex_bias, tuple(target.shape), 'Norm ex_bias')
+    return True
+
+
+def test_full_basic_load():
+    state_dict = sd_full_proj()
+    net = _load_via(F.try_load_full, state_dict)
+    assert net is not None and len(net.modules) == 1
+    mod = next(iter(net.modules.values()))
+    assert isinstance(mod, network_full.NetworkModuleFull)
+    target = mod.sd_module.weight
+    updown, ex_bias = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape), 'Full updown')
+    assert ex_bias is not None and tuple(ex_bias.shape) == (HIDDEN,), f'Full ex_bias shape {ex_bias.shape if ex_bias is not None else None}'
+    return True
+
+
+# ============================================================
+# Tests — calc_updown sanity per family
+# ============================================================
+
+CAT_MATH = category('math')
+
+
+def _instantiate_first(net):
+    """Convenience: pull the only module out of a single-module Network."""
+    assert net is not None and len(net.modules) == 1
+    return next(iter(net.modules.values()))
+
+
+def test_lora_calc_updown_shape():
+    mod = _instantiate_first(_load_via(F.try_load_lora, sd_lora_bfl_proj()))
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape))
+    assert_finite(updown)
+    return True
+
+
+def test_lokr_calc_updown_shape():
+    mod = _instantiate_first(_load_via(F.try_load_lokr, sd_lokr_bfl_proj()))
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape))
+    assert_finite(updown)
+    return True
+
+
+def test_lokr_chunk_calc_updown_shape():
+    """LokrChunk produces a (QKV_OUT, HIDDEN) chunk from a (3*QKV_OUT, HIDDEN) full kron."""
+    net = _load_via(F.try_load_lokr, sd_lokr_kohya_qkv())
+    for mod in net.modules.values():
+        target = mod.sd_module.weight  # split projection: shape (HIDDEN, QKV_OUT) for to_q etc.
+        updown, _ = mod.calc_updown(target)
+        # `target.shape` is (out=QKV_OUT, in=HIDDEN) for the diffusers Linear; the chunk class
+        # returns the chunk of kron(w1,w2) sliced along dim 0 (the fused-output axis).
+        assert_shape(updown, (QKV_OUT, HIDDEN))
+        assert_finite(updown)
+    return True
+
+
+def test_loha_calc_updown_shape():
+    mod = _instantiate_first(_load_via(F.try_load_loha, sd_loha_bfl_proj()))
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape))
+    assert_finite(updown)
+    return True
+
+
+def test_loha_chunk_calc_updown_shape():
+    """HadaChunk produces a (QKV_OUT, HIDDEN) chunk per Q/K/V."""
+    net = _load_via(F.try_load_loha, sd_loha_kohya_qkv())
+    for mod in net.modules.values():
+        target = mod.sd_module.weight
+        updown, _ = mod.calc_updown(target)
+        assert_shape(updown, (QKV_OUT, HIDDEN))
+        assert_finite(updown)
+    return True
+
+
+def test_oft_calc_updown_shape():
+    mod = _instantiate_first(_load_via(F.try_load_oft, sd_oft_kohya_proj()))
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape))
+    assert_finite(updown)
+    return True
+
+
+def test_ia3_calc_updown_shape():
+    mod = _instantiate_first(_load_via(F.try_load_ia3, sd_ia3_proj()))
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    # IA3 returns target * w; output shape matches target.
+    assert_shape(updown, tuple(target.shape))
+    assert_finite(updown)
+    return True
+
+
+def test_glora_calc_updown_shape():
+    mod = _instantiate_first(_load_via(F.try_load_glora, sd_glora_proj()))
+    target = mod.sd_module.weight
+    updown, _ = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape))
+    assert_finite(updown)
+    return True
+
+
+def test_full_calc_updown_shape():
+    mod = _instantiate_first(_load_via(F.try_load_full, sd_full_proj()))
+    target = mod.sd_module.weight
+    updown, ex_bias = mod.calc_updown(target)
+    assert_shape(updown, tuple(target.shape))
+    assert_shape(ex_bias, (HIDDEN,))
+    assert_finite(updown)
+    return True
+
+
+# ============================================================
+# Tests — apply path / regressions in shared infra
+# ============================================================
+
+CAT_APPLY = category('apply')
+
+
+def test_ex_bias_accumulation_two_norms():
+    """Stacking two Norm adapters that both produce ex_bias accumulates
+    correctly: network_calc_weights sums their contributions instead of
+    raising on a tensor truthiness check.
+    """
+    install_mock_pipe()
+    norm_module = shared.sd_model.pipe.transformer.transformer_blocks[0].attn.norm_q
+
+    # Build two Norm Networks targeting the same norm module.
+    state_dict_a = {
+        'transformer.transformer_blocks.0.attn.norm_q.w_norm': torch.full((HEAD_DIM,), 0.01),
+        'transformer.transformer_blocks.0.attn.norm_q.b_norm': torch.full((HEAD_DIM,), 0.02),
+    }
+    state_dict_b = {
+        'transformer.transformer_blocks.0.attn.norm_q.w_norm': torch.full((HEAD_DIM,), 0.03),
+        'transformer.transformer_blocks.0.attn.norm_q.b_norm': torch.full((HEAD_DIM,), 0.04),
+    }
+    nets = []
+    for label, sd in (('a', state_dict_a), ('b', state_dict_b)):
+        with TempLora(sd, name=f'norm_{label}') as nod:
+            n = F.try_load_norm(f'norm_{label}', nod, lora_scale=1.0)
+        n.te_multiplier = 1.0
+        n.unet_multiplier = 1.0
+        nets.append(n)
+
+    # Patch loaded_networks for the duration of this test.
+    saved_loaded = list(l_common.loaded_networks)
+    l_common.loaded_networks.clear()
+    l_common.loaded_networks.extend(nets)
+    try:
+        # network_calc_weights iterates loaded_networks and hits the
+        # `if batch_ex_bias:` line on the second adapter.
+        layer_name = norm_module.network_layer_name
+        # Bind layer_name in case prior test cleared it.
+        if not layer_name:
+            from modules.lora import lora_convert
+            lora_convert.assign_network_names_to_compvis_modules(shared.sd_model.pipe)
+            layer_name = 'lora_transformer_transformer_blocks_0_attn_norm_q'
+            norm_module.network_layer_name = layer_name
+        batch_updown, batch_ex_bias = lora_apply.network_calc_weights(norm_module, layer_name)
+        assert batch_updown is not None, 'batch_updown should be present (two w_norm contributions)'
+        assert batch_ex_bias is not None, 'batch_ex_bias should be present (two b_norm contributions)'
+        assert_shape(batch_ex_bias, (HEAD_DIM,))
+        # Two contributions of 0.02 + 0.04 = 0.06 (pre-multiplier).
+        # multiplier()=te_multiplier=1.0 for both; finalize_updown applies it to ex_bias.
+        expected_b = 0.02 + 0.04
+        assert torch.allclose(batch_ex_bias, torch.full_like(batch_ex_bias, expected_b), atol=1e-5), \
+            f'ex_bias accumulated to {batch_ex_bias[0].item():.6f}, expected {expected_b:.6f}'
+    finally:
+        l_common.loaded_networks.clear()
+        l_common.loaded_networks.extend(saved_loaded)
+    return True
+
+
+# ============================================================
+# Test runner
+# ============================================================
+
+
+def run_tests():
+    t0 = time.time()
+
+    log.warning('=== Parsing primitives ===')
+    for fn in [test_parse_key_all_prefixes, test_resolve_targets_qkv_chunking,
+               test_parse_key_peft_wrapper_unwrap, test_parse_key_lycoris_prefix,
+               test_parse_key_bare_diffusers_and_peft_default,
+               test_marker_disambiguation]:
+        run_test(CAT_PARSE, fn)
+
+    log.warning('=== Loaders ===')
+    for fn in [
+        test_lora_kohya_fused_qkv_chunked,
+        test_lora_bfl_non_fused,
+        test_lora_peft_format,
+        test_lora_bare_bfl_format,
+        test_lora_peft_saved_fal_style,
+        test_lora_peft_saved_dreambooth_style,
+        test_lora_peft_saved_diffusers_style,
+        test_lora_dora_threading,
+        test_lokr_bfl_non_fused,
+        test_lokr_kohya_fused_qkv_chunked,
+        test_lokr_simpletuner_lycoris_format,
+        test_loha_bfl_non_fused,
+        test_loha_kohya_fused_qkv_chunked,
+        test_oft_kohya_non_fused,
+        test_oft_lycoris_no_npe,
+        test_oft_fused_qkv_skipped,
+        test_boft_loads_and_applies,
+        test_ia3_basic_load,
+        test_ia3_fused_qkv_skipped,
+        test_glora_basic_load_and_alpha,
+        test_norm_loader_local_stamping,
+        test_full_basic_load,
+    ]:
+        run_test(CAT_LOADER, fn)
+
+    log.warning('=== calc_updown shape sanity ===')
+    for fn in [
+        test_lora_calc_updown_shape,
+        test_lokr_calc_updown_shape,
+        test_lokr_chunk_calc_updown_shape,
+        test_loha_calc_updown_shape,
+        test_loha_chunk_calc_updown_shape,
+        test_oft_calc_updown_shape,
+        test_ia3_calc_updown_shape,
+        test_glora_calc_updown_shape,
+        test_full_calc_updown_shape,
+    ]:
+        run_test(CAT_MATH, fn)
+
+    log.warning('=== Apply path / shared-infra regressions ===')
+    for fn in [test_ex_bias_accumulation_two_norms]:
+        run_test(CAT_APPLY, fn)
+
+    elapsed = time.time() - t0
+
+    log.warning('=== Results ===')
+    total_passed = 0
+    total_failed = 0
+    for cat, data in results.items():
+        total_passed += data['passed']
+        total_failed += data['failed']
+        status = 'PASS' if data['failed'] == 0 else 'FAIL'
+        log.info(f'  {cat}: {data["passed"]} passed, {data["failed"]} failed [{status}]')
+    log.warning(f'Total: {total_passed} passed, {total_failed} failed in {elapsed:.2f}s')
+    if total_failed:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
## Description

Quick and easy, no problem. Enjoy the War & Peace below. Though 90% the diff is the test and the reshuffle of the flux2 loader rather than new code and most of the description is just for mine and your sanity.

This is sort of in preparation to start hoisting the functions into helpers, even without rolling out the peer support for other arches we're decently into hundreds of verbatim duplicated LOC across the native loaders. Once that lands the vast majority of the maintenance burden will be there and centralised, rather than over the who knows how many separate loaders.

Plug the gaps in Flux2/Klein native adapter support. Before this branch only LoRA and LoKR loaded natively, everything else was either rejected or routed through PEFT. After: full LyCORIS menu (LoRA, LoKR, LoHA, OFT, BOFT, IA3, GLoRA, Norm, Full) loads natively, plus expanded prefix-format coverage for save layouts observed in the wild.

## Notes

### Latent bug fixes in shared LoRA infra

- `network_oft.py:58`: guard `self.constraint.to(...)` for the LyCORIS `oft_diag` path
- `network_glora.py.__init__`: set `self.dim = self.w1b.shape[0]` so `calc_scale` honors alpha
- `lora_apply.py:115`: `if batch_ex_bias is not None` (hits when two Norm adapters target the same module)
- First three commits of the branch, bisects cleanly if you want to cherry-pick to `dev` independently

### New shared module

- `NetworkModuleHadaChunk` in `network_hada.py`, mirrors `NetworkModuleLokrChunk`'s constructor shape
- Slices `w1a` / `w2a` at the chunk's row range and computes the partial Hadamard
- Tucker LoHAs aren't handled. LyCORIS only saves `hada_t1` / `hada_t2` for non-1x1 Conv and fused QKV is always Linear, so the combination can't arise from a conformant trainer

### Flux2 loader

- Refactored `pipelines/flux/flux2_lora.py` around shared scaffolding (parameterized `parse_key`, `group_by_suffixes`, `resolve_targets`, `finalize_network`) so each new family loader is a thin specialization
- Seven new `try_load_*` entry points
- Per-family fused-QKV handling:
  - LoRA: load-time chunk of `lora_up` along dim 0
  - LoKR: apply-time slice via `NetworkModuleLokrChunk`
  - LoHA: apply-time slice via `NetworkModuleHadaChunk` (Tucker variants on fused targets are skipped)
  - OFT / BOFT / IA3 / GLoRA / Full: fused groups skipped with warning
  - Norm: never fused
- OFT and BOFT share the `oft_blocks` save key and discriminate via `ndim` (3-D OFT, 4-D BOFT), mirroring upstream `algo_check`
- BOFT `make_weight` ports verbatim from `lycoris/modules/boft.py`
- Norm uses loader-local `network_layer_name` stamping on the modules it actually binds, sidestepping `lora_convert.py:502`'s transformer-norm guard without touching the shared carve-out
- DoRA threads through automatically via `dora_scale` in `weights.w` plus the existing `apply_weight_decompose` in `network.NetworkModule.finalize_updown`. No subclass plumbing.

### Dispatcher migration

- Added `'f2'` to `allow_native` in `lora_overrides`
- Moved Flux2 dispatch out of the inline diffusers branch in `network_load` and into `load_safetensors`, after the chroma branch
- Dispatch order: LoRA, LoKR, LoHA, OFT, IA3, GLoRA, Norm, Full
- **Behavior change worth flagging**: Flux2 LoRA files that fail every native loader no longer fall through to PEFT silently. They fail with the standard "not loaded" log. `lora_force_diffusers=True` is the documented "escape" hatch. Hardly escaping anything given PEFT is more barren than the Moon, but honestly for me it's more of a feature rather than a problem, since I'd rather know if it doesn't work rather than rely on the mess that is PEFT.

### Format coverage

- Recognized prefix forms after this branch:
  - `diffusion_model.` (BFL / AI-toolkit)
  - `transformer.` (diffusers PEFT in-memory)
  - `lora_unet_` (kohya)
  - `lycoris_` (LyCORIS-standalone, e.g. SimpleTuner LoKR)
  - `base_model.model.` (`peft.save_pretrained` wrapper, stripped pre-parse)
  - bare BFL paths (`double_blocks.`, `single_blocks.`, etc.)
  - bare diffusers paths (`single_transformer_blocks.`, `transformer_blocks.`, produced by `Flux2Transformer2DModel.save_lora_adapter()`)
- `.lora_[AB].<adapter_name>.weight` infix strip so PEFT named-adapter saves match the standard suffix table (`default` is the implicit name when an adapter is added without one)

### Logging

- `lora_overrides.get_method` now returns `(method, reason)`
- Reason folded into the always-visible `Network load: ... load=<method>(<reason>)` info line in `extra_networks_lora.activate` so users can see why a file took the diffusers path vs native without flipping any debug flag
- Also threaded into the existing `lora_diffusers.load_diffusers` debug line and the `extra_networks_lora.activate` trace line for completeness

### LyCORIS coverage relative to upstream

- Native: LoRA, LoKR, LoHA, OFT, BOFT, IA3, GLoRA, Norm, Full
- Saved as standard LoRA at upstream save time:
  - LoCon (bakes `scalar` into `lora_up`)
  - DyLoRA (concats per-block slabs into a max-rank matrix)
  - Both load via `try_load_lora` losslessly relative to upstream's own export
- Deferred: TLoRA. The on-disk format saves only `q_layer` / `p_layer` / `lambda_layer` / `alpha`; `base_q` / `base_p` / `base_lambda` and `sig_type` are unrecoverable, so any loader has a silent-correctness gap for `sig_type != 'principal'`. Files fail with "not loaded" rather than apply incorrectly. They also apparently use SVD conversion in their implementation too, which I'm just not cut out to deal with at the moment.

### Tests

- 38 offline tests in `test/test-flux2-native-adapters.py`
- Mocks a Flux2-shaped transformer module tree, builds synthetic state dicts per family and format combination, drives them through the loaders end-to-end
- Covers parse primitives, all 9 family loaders, `calc_updown` shape sanity, `ex_bias` accumulation across two Norm adapters, OFT/BOFT discrimination, Tucker-fused-QKV skip warning, bare-diffusers + PEFT-named-adapter parse cases

## Environment and Testing

- 38/38 offline tests pass (`venv/bin/python test/test-flux2-native-adapters.py`)
- `npm run lint` clean
- Real-world: 5 distinct format paths exercised in a single Klein 9B session (one model load, five LoRA swaps): BFL/AI-toolkit (`KleinBase9B_ProductImage`), kohya (`Ref2FontV3`), PEFT (`Anything2Real V2`), bare-diffusers / PEFT save ***(wtf?)***(`lenovo_flux_klein9b`), LoKR (`Realism_Engine_Klein_V2`). All loaded with `unmapped=0 mismatch=0 skipped=0`. Stacked 5-LoRA generation completed without errors.