### PR TITLE
fix(installer): support ssh remotes in repo update check

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1382,7 +1382,16 @@ def get_version(force=False):
         try:
             origin = run('git', 'remote get-url origin', check=True)[0].stdout
             branch_name = run('git', 'rev-parse --abbrev-ref HEAD', check=True)[0].stdout
-            version['url'] = origin.removesuffix('.git') + '/tree/' + branch_name
+            # normalize ssh remotes (git@host:owner/repo) and ssh-protocol remotes
+            # (ssh://git@host/owner/repo) to the canonical https form so downstream
+            # url parsers don't have to special-case each remote shape
+            if origin.startswith('git@'):
+                host, _, path = origin.partition(':')
+                origin = f'https://{host[4:]}/{path}'
+            elif origin.startswith('ssh://'):
+                origin = 'https://' + origin[len('ssh://'):].split('@', 1)[-1]
+            origin = origin.removesuffix('.git')
+            version['url'] = origin + '/tree/' + branch_name
             version['branch'] = branch_name
             if version['branch'] == 'HEAD':
                 log.warning('Version: detached state detected')
@@ -1539,6 +1548,9 @@ def check_version(reset=True): # pylint: disable=unused-argument
         else:
             api_base = 'https://api.github.com/repos/vladmandic/sdnext'
         branches = requests.get(f'{api_base}/branches', timeout=5).json()
+        if not isinstance(branches, list):
+            log.error(f'Repository: branches API returned {branches!r} from {api_base}')
+            return
         branch_names = [b['name'] for b in branches if 'name' in b]
         log.trace(f'Repository branches: active={branch_name} available={branch_names}')
     except Exception as e:


### PR DESCRIPTION
Fixes an issue only existing in update code which prevents sd.next from working if git is configured via SSH.

`get_version()` previously stored the raw `git remote get-url origin` output in `ver['url']`. For ssh-form remotes (`git@host:owner/repo` or `ssh://git@host/owner/repo`), the GitHub branches API url builder in `check_version()`, which strips the `https://github.com/` prefix, produced a malformed url that returned 404. The 404 response (a dict with `message`) was then iterated by a list comprehension filtering on `'name' in b`, yielding an empty branch list and a misleading "branch=dev skipping update" warning.

- normalize ssh and ssh:// remotes to canonical https form in `get_version()`, so every consumer of `ver['url']` sees one shape
- guard `check_version()` against non-list api responses with an `isinstance` check that logs the actual payload instead of silently yielding `[]`