### PR TITLE
Update Pillow support to 12.2.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,3 @@
 fastapi==0.124.4
 numpy==2.1.2
-Pillow==10.4.0
+Pillow==12.2.0

--- a/modules/sharpfin/cms.py
+++ b/modules/sharpfin/cms.py
@@ -1,36 +1,39 @@
+from __future__ import annotations
+
 """Sharpfin color management (ICC profile handling).
 
 Vendored from https://github.com/drhead/sharpfin (Apache 2.0)
 """
 
 from io import BytesIO
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from warnings import warn
 
 import numpy as np
-from torch import Tensor
 
-import PIL.Image as image
-import PIL.ImageCms as image_cms
-
-from PIL.Image import Image
+from PIL import Image
 from PIL.ImageCms import (
     Direction, Intent, ImageCmsProfile, PyCMSError,
     createProfile, getDefaultIntent, isIntentSupported, profileToProfile
 )
+from PIL.ImageCms import Flags as cms_flags
 from PIL.ImageOps import exif_transpose
 
-image.MAX_IMAGE_PIXELS = None
+if TYPE_CHECKING:
+    from PIL import ImageFile
+    from torch import Tensor
+
+Image.MAX_IMAGE_PIXELS = None
 
 _SRGB = createProfile(colorSpace='sRGB')
 
 _INTENT_FLAGS = {
-    Intent.PERCEPTUAL: image_cms.FLAGS["HIGHRESPRECALC"],
+    Intent.PERCEPTUAL: cms_flags.HIGHRESPRECALC,
     Intent.RELATIVE_COLORIMETRIC: (
-        image_cms.FLAGS["HIGHRESPRECALC"] |
-        image_cms.FLAGS["BLACKPOINTCOMPENSATION"]
+        cms_flags.HIGHRESPRECALC |
+        cms_flags.BLACKPOINTCOMPENSATION
     ),
-    Intent.ABSOLUTE_COLORIMETRIC: image_cms.FLAGS["HIGHRESPRECALC"]
+    Intent.ABSOLUTE_COLORIMETRIC: cms_flags.HIGHRESPRECALC
 }
 
 class CMSWarning(UserWarning):
@@ -71,13 +74,8 @@ def _add_info(info: dict[str, Any], source: object, key: str) -> None:
     except Exception:
         pass
 
-def apply_srgb(
-    img: Image
-) -> Image:
-    if hasattr(img, 'filename'):
-        path = img.filename
-    else:
-        path = ""
+def apply_srgb(img: Image.Image | ImageFile.ImageFile) -> Image.Image:
+    path = getattr(img, "filename", "")
 
     try:
         img.load()
@@ -131,7 +129,7 @@ def apply_srgb(
                             flags=flags
                         )
                     else:
-                        img = cast('Image', profileToProfile(
+                        img = cast('Image.Image', profileToProfile(
                             img,
                             profile,
                             _SRGB,
@@ -167,7 +165,7 @@ def apply_srgb(
 
     return img
 
-def put_srgb(img: Image, tensor: Tensor) -> None:
+def put_srgb(img: Image.Image, tensor: Tensor) -> None:
     if img.mode not in ("RGB", "RGBA", "RGBa"):
         raise ValueError(f"Image has non-RGB mode {img.mode}.")
 

--- a/pipelines/lumina_dimmo/lumina_dimoo.py
+++ b/pipelines/lumina_dimmo/lumina_dimoo.py
@@ -1687,7 +1687,7 @@ def preprocess_image(image: Image.Image):
     image = image.convert("RGB")
     w, h = image.size
     w, h = (x - x % 32 for x in (w, h))
-    image = image.resize((w, h), resample=Image.LANCZOS)
+    image = image.resize((w, h), resample=Image.Resampling.LANCZOS)
     image = np.array(image).astype(np.float32) / 255.0
     image = image[None].transpose(0, 3, 1, 2)
     image = torch.from_numpy(image)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pandas==2.3.1
 protobuf==6.33.5
 pytorch_lightning==2.6.1
 urllib3==1.26.19
-Pillow==10.4.0
+Pillow==12.2.0
 timm==1.0.24
 pyparsing==3.3.2
 typing-extensions==4.15.0


### PR DESCRIPTION
- Update "constraints.txt" and "requirements.txt".
- Migrate removed `ImageCms.FLAGS` to `ImageCms.Flags` enum.
- Update typing.
- Simplify getting path in `apply_srgb`.
- ~~Fix incorrect~~ Update Enum in `lumina_dimoo.py`.

The ImageCms flags to enum was the only breaking change as far as I can tell.

In terms of deprecations, there's just the change to [Image.fromarray mode parameter](https://pillow.readthedocs.io/en/stable/deprecations.html#image-fromarray-mode-parameter) where usage of the `mode` parameter is meant for just a few specific scenarios now. The old behavior is still allowed, so I didn't change any of the handful of instances where it's used.

One advantage of updating Pillow is better typing leading to fewer false positives.