### PR TITLE
Use ModuleType directly

### DIFF
--- a/modules/modeldata.py
+++ b/modules/modeldata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 from modules import errors, shared
@@ -210,7 +211,7 @@ model_data = ModelData()
 
 
 # provides shared.sd_model field as a property
-class Shared(sys.modules[__name__].__class__):
+class Shared(ModuleType):
     @property
     def sd_loaded(self):
         return model_data.sd_model is not None


### PR DESCRIPTION
Reference `ModuleType` directly instead of the current (and weird) roundabout method.

Docs: https://docs.python.org/3/reference/datamodel.html#customizing-module-attribute-access