### PR TITLE
fix(lora): natural-filename lookup on windows and in subfolders

### DIFF
--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -214,6 +214,13 @@ def list_available_networks():
             available_network_aliases[entry.name] = entry
             if entry.fullname != entry.name:
                 available_network_aliases[entry.fullname] = entry
+            # entry.name mangles dots to underscores for legacy reasons and entry.fullname
+            # carries any subfolder prefix, so neither matches when the user types the file's
+            # natural basename. setdefault avoids clobbering an explicit primary entry when
+            # two files in different subfolders share a basename.
+            basename_alias = os.path.splitext(os.path.basename(filename))[0]
+            if basename_alias and basename_alias not in (entry.name, entry.fullname):
+                available_network_aliases.setdefault(basename_alias, entry)
             if entry.shorthash:
                 available_network_hash_lookup[entry.shorthash] = entry
         except OSError as e: # should catch FileNotFoundError and PermissionError etc.

--- a/modules/lora/network.py
+++ b/modules/lora/network.py
@@ -27,7 +27,10 @@ class NetworkOnDisk:
         self.name = name
         self.filename = filename
         if filename.startswith(shared.cmd_opts.lora_dir):
-            self.fullname = os.path.splitext(filename[len(shared.cmd_opts.lora_dir):].strip("/"))[0]
+            # strip("/") missed Windows's leading backslash after the slice; normalize separators
+            # so the registry key is one canonical form on every OS.
+            rel = filename[len(shared.cmd_opts.lora_dir):].lstrip('/\\').replace('\\', '/')
+            self.fullname = os.path.splitext(rel)[0] if rel else name
         else:
             self.fullname = name
         self.metadata = {}


### PR DESCRIPTION
## Description

NetworkOnDisk.fullname stripped only `"/"` from the `post-lora_dir` slice, leaving a leading `"\"` on Windows. Every prompt typing the file's natural dot-form name missed both registered aliases. On Linux, dot-form lookup already missed when the file lived in any subfolder because only the subfolder-prefixed form was registered.

## Notes


- `network.py`: lstrip both separators and normalize backslashes to forward slashes so fullname has one canonical shape per OS.
- `lora_load.py`: register a bare-basename-with-dots alias so typing `<lora:my.lora:1>` resolves regardless of subfolder placement. `setdefault` preserves explicit primary registrations on cross-subfolder basename collisions.

Existing prompts using the legacy dots-to-underscores form continue to resolve via entry.name unchanged.
