### PR TITLE
fix(paths): don't create per-type output dirs at root when base set

### DIFF
--- a/modules/paths.py
+++ b/modules/paths.py
@@ -116,25 +116,30 @@ def create_paths(opts):
     create_path(fix_path('embeddings_dir'))
     create_path(fix_path('onnx_temp_dir'))
     create_path(fix_path('outdir_samples'))
-    create_path(fix_path('outdir_txt2img_samples'))
-    create_path(fix_path('outdir_img2img_samples'))
-    create_path(fix_path('outdir_control_samples'))
-    create_path(fix_path('outdir_extras_samples'))
-    create_path(fix_path('outdir_init_images'))
     create_path(fix_path('outdir_grids'))
-    create_path(fix_path('outdir_txt2img_grids'))
-    create_path(fix_path('outdir_img2img_grids'))
-    create_path(fix_path('outdir_control_grids'))
-    create_path(fix_path('outdir_save'))
-    create_path(fix_path('outdir_video'))
+    # per-type output dirs resolve against data_path via fix_path(), so create them bare
+    # only when no base folder is set; with a base configured, the resolved base+specific
+    # paths below are the real targets and the bare versions would just litter data_path
+    base_samples = opts.data.get('outdir_samples', '')
+    base_grids = opts.data.get('outdir_grids', '')
+    if not base_samples:
+        create_path(fix_path('outdir_txt2img_samples'))
+        create_path(fix_path('outdir_img2img_samples'))
+        create_path(fix_path('outdir_control_samples'))
+        create_path(fix_path('outdir_extras_samples'))
+        create_path(fix_path('outdir_init_images'))
+        create_path(fix_path('outdir_save'))
+        create_path(fix_path('outdir_video'))
+    if not base_grids:
+        create_path(fix_path('outdir_txt2img_grids'))
+        create_path(fix_path('outdir_img2img_grids'))
+        create_path(fix_path('outdir_control_grids'))
     create_path(fix_path('styles_dir'))
     create_path(fix_path('yolo_dir'))
     create_path(fix_path('wildcards_dir'))
     create_path(fix_path('autocomplete_dir'))
 
     # Create resolved output paths (base + specific)
-    base_samples = opts.data.get('outdir_samples', '')
-    base_grids = opts.data.get('outdir_grids', '')
     if base_samples:
         create_path(resolve_output_path(base_samples, opts.data.get('outdir_txt2img_samples', '')))
         create_path(resolve_output_path(base_samples, opts.data.get('outdir_img2img_samples', '')))


### PR DESCRIPTION
## Description

Fixes subfolders for outputs being created in repo root when base output folder was configured.

## Notes

`create_paths()` pre-created every per-type output folder via `fix_path()`, which resolves relative values against `data_path` (the repo root). With a base images/grids folder configured, those bare dirs are never written to (generation uses the base-joined path), so they accumulate as empty stray folders at the repo root on every launch. Guard the bare creations behind an unset base; the resolved base+specific block already creates the real targets.