### PR TITLE
feat(video): save prompt metadata in mp4

### DIFF
--- a/modules/video_models/video_save.py
+++ b/modules/video_models/video_save.py
@@ -55,6 +55,29 @@ def save_params(p, filename: str | None = None):
         file.write(params)
 
 
+def create_video_metadata(p: processing.StableDiffusionProcessingVideo | None, metadata: dict | None = None, filename: str | None = None):
+    metadata = metadata.copy() if metadata is not None else {}
+    if not shared.opts.image_metadata:
+        return metadata
+    if p is None:
+        return metadata
+    try:
+        info = processing.create_infotext(p)
+    except Exception as e:
+        log.debug(f'Video metadata: infotext failed: {e}')
+        info = ''
+    if len(info) == 0:
+        info = getattr(p, 'prompt', '') or ''
+    if len(info) == 0:
+        return metadata
+    title = os.path.basename(filename) if filename else 'SD.Next video'
+    metadata.setdefault('title', title)
+    metadata.setdefault('encoder', 'SD.Next')
+    metadata.setdefault('comment', info)
+    metadata.setdefault('description', info)
+    return metadata
+
+
 def images_to_tensor(images):
     if images is None or len(images) == 0:
         return None
@@ -310,6 +333,7 @@ def save_video(
 
         if mp4_video and (mp4_codec != 'none'):
             output_video = f'{output_filename}.{mp4_ext}'
+            metadata = create_video_metadata(p, metadata, output_filename)
             atomic_save_video(output_video, tensor=x, audio=audio, fps=mp4_fps, codec=mp4_codec, options=mp4_opt, aac=aac_sample_rate, metadata=metadata, pbar=pbar)
             if stream is not None:
                 stream.output_queue.push(('progress', (None, f'Video {os.path.basename(output_video)} | Codec {mp4_codec} | Size {w}x{h}x{t} | FPS {mp4_fps}')))


### PR DESCRIPTION
## Description

Adds prompt/generation metadata to MP4 files saved by the main PyAV video generation path, similar to how image generation stores infotext in image metadata.

This makes generated video prompts and settings visible in players that expose MP4 metadata, including VLC.

## Notes

The metadata is added only for PyAV-encoded video outputs. OpenCV/PIL video paths and raw binary video outputs are intentionally unchanged.

The implementation:
- Respects the existing `image_metadata` setting.
- Writes infotext to MP4 `comment` and `description` fields for broader player visibility.
- Defaults the MP4 `title` to the generated output filename slug.
- Preserves caller-provided metadata, including existing FramePack metadata.

One caveat: ffmpeg/PyAV may overwrite the `encoder` field with its own `Lavf...` value, but `title`, `comment`, and `description` are preserved.

## Environment and Testing

Tested on Fedora 44 Kinoite with ROCm.

Validation performed:
- `python -m py_compile modules/video_models/video_save.py`
- `ruff check modules/video_models/video_save.py`
- Encoded a small MP4 through the PyAV save helper and verified metadata readback with PyAV:
  - `title`
  - `comment`
  - `description`

Also verified manually that the metadata is visible in VLC.