### PR TITLE
Fix/sampler fallback paths

### DIFF
--- a/modules/errors.py
+++ b/modules/errors.py
@@ -10,6 +10,10 @@ install_traceback()
 already_displayed = {}
 
 
+class ValidationError(ValueError):
+    """Expected validation failure: display() reports the message without a traceback."""
+
+
 def install(suppress=None):
     if suppress is None:
         suppress = []
@@ -22,6 +26,9 @@ def display(e: Exception, task: str, suppress=None):
     if suppress is None:
         suppress = []
     if isinstance(e, ErrorLimiterAbort):
+        return
+    if isinstance(e, ValidationError):
+        log.error(f"{task or 'error'}: {e}")
         return
     log.error(f"{task or 'error'}: {type(e).__name__}")
     """

--- a/modules/processing_helpers.py
+++ b/modules/processing_helpers.py
@@ -584,9 +584,9 @@ def update_sampler(p, sd_model, second_pass=False):
         if sampler_selection == 'None':
             return
         sampler = sd_samplers.find_sampler(sampler_selection)
-        if sampler is None:
-            log.warning(f'Sampler: "{sampler_selection}" not found')
-            sampler = sd_samplers.all_samplers_map.get("UniPC")
+        resolved = sampler is not None
+        if not resolved:
+            log.warning(f'Sampler: name="{sampler_selection}" not found')
         sched_override_keys = [
             'schedulers_prediction_type', 'schedulers_beta_schedule', 'schedulers_timesteps',
             'schedulers_sigma', 'schedulers_use_thresholding', 'schedulers_use_loworder',
@@ -596,8 +596,8 @@ def update_sampler(p, sd_model, second_pass=False):
             'schedulers_timestep_spacing', 'schedulers_timesteps_range',
         ]
         scheduler_overrides = {k: getattr(p, k) for k in sched_override_keys if getattr(p, k, None) is not None}
-        sampler = sd_samplers.create_sampler(sampler.name, sd_model, scheduler_overrides=scheduler_overrides)
-        if sampler is None or sampler_selection == 'Default':
+        sampler = sd_samplers.create_sampler(sampler.name if resolved else sampler_selection, sd_model, scheduler_overrides=scheduler_overrides)
+        if sampler is None or not resolved or sampler_selection == 'Default':
             if second_pass:
                 p.hr_sampler = 'Default'
             else:

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -1,6 +1,6 @@
 import os
 import copy
-from modules import shared
+from modules import shared, errors
 from modules.logger import log
 
 
@@ -108,7 +108,7 @@ def create_sampler(name, model, scheduler_overrides=None):
 
     if config is None or config.constructor is None:
         if debug or not shared.opts.schedulers_fallback:
-            raise ValueError(f'Sampler: name="{name}" unknown')
+            raise errors.ValidationError(f'Sampler: name="{name}" unknown')
         return restore_default(model, name)
 
     from modules import sd_samplers_diffusers
@@ -129,13 +129,13 @@ def create_sampler(name, model, scheduler_overrides=None):
     elif (model is not None) and (is_flow and not requires_flow):
         log.error(f'Sampler: "{sampler.name}" cls={sampler.sampler.__class__.__name__} pipe={model.__class__.__name__} type={pred_type} model requires sampler with discrete prediction')
         if debug or not shared.opts.schedulers_fallback:
-            raise ValueError(f'Sampler: name="{sampler.name}" cls={sampler.sampler.__class__.__name__} type={pred_type} model requires sampler with discrete prediction')
+            raise errors.ValidationError(f'Sampler: name="{sampler.name}" cls={sampler.sampler.__class__.__name__} type={pred_type} model requires sampler with discrete prediction')
         else:
             return restore_default(model, name)
     elif (model is not None) and (not is_flow and requires_flow):
         log.error(f'Sampler: "{sampler.name}" cls={sampler.sampler.__class__.__name__} pipe={model.__class__.__name__} type={pred_type} model requires sampler with flow prediction')
         if debug or not shared.opts.schedulers_fallback:
-            raise ValueError(f'Sampler: name="{sampler.name}" cls={sampler.sampler.__class__.__name__} type={pred_type} model requires sampler with flow prediction')
+            raise errors.ValidationError(f'Sampler: name="{sampler.name}" cls={sampler.sampler.__class__.__name__} type={pred_type} model requires sampler with flow prediction')
         else:
             return restore_default(model, name)
 

--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -15,7 +15,7 @@ loaded_config = None
 
 def find_sampler(name:str):
     if name is None or name == 'None':
-        return all_samplers_map.get("UniPC", None)
+        return all_samplers_map.get("Default", None)
     for sampler in all_samplers:
         if sampler.name.lower() == name.lower() or name in sampler.aliases:
             return sampler
@@ -107,6 +107,8 @@ def create_sampler(name, model, scheduler_overrides=None):
         config = find_sampler_config(name)
 
     if config is None or config.constructor is None:
+        if debug or not shared.opts.schedulers_fallback:
+            raise ValueError(f'Sampler: name="{name}" unknown')
         return restore_default(model, name)
 
     from modules import sd_samplers_diffusers
@@ -126,16 +128,16 @@ def create_sampler(name, model, scheduler_overrides=None):
         pass
     elif (model is not None) and (is_flow and not requires_flow):
         log.error(f'Sampler: "{sampler.name}" cls={sampler.sampler.__class__.__name__} pipe={model.__class__.__name__} type={pred_type} model requires sampler with discrete prediction')
-        if not debug:
-            return restore_default(model, name)
-        else:
+        if debug or not shared.opts.schedulers_fallback:
             raise ValueError(f'Sampler: name="{sampler.name}" cls={sampler.sampler.__class__.__name__} type={pred_type} model requires sampler with discrete prediction')
+        else:
+            return restore_default(model, name)
     elif (model is not None) and (not is_flow and requires_flow):
         log.error(f'Sampler: "{sampler.name}" cls={sampler.sampler.__class__.__name__} pipe={model.__class__.__name__} type={pred_type} model requires sampler with flow prediction')
-        if not debug:
-            return restore_default(model, name)
-        else:
+        if debug or not shared.opts.schedulers_fallback:
             raise ValueError(f'Sampler: name="{sampler.name}" cls={sampler.sampler.__class__.__name__} type={pred_type} model requires sampler with flow prediction')
+        else:
+            return restore_default(model, name)
 
     # assign sampler
     if model is not None:

--- a/modules/sd_samplers_diffusers.py
+++ b/modules/sd_samplers_diffusers.py
@@ -519,6 +519,8 @@ class DiffusionSampler:
             log.error(f'Sampler: "{name}" {e}')
             if debug:
                 errors.display(e, 'Samplers')
+            if debug or not shared.opts.schedulers_fallback:
+                raise
             self.sampler = None
             return
 

--- a/modules/sd_samplers_diffusers.py
+++ b/modules/sd_samplers_diffusers.py
@@ -450,7 +450,7 @@ class DiffusionSampler:
                 sigma_applied = True
             if not sigma_applied:
                 if debug or not shared.opts.schedulers_fallback:
-                    raise ValueError(f'Sampler: name="{name}" does not support sigma="{sched_sigma}"')
+                    raise errors.ValidationError(f'Sampler: name="{name}" does not support sigma="{sched_sigma}"')
                 else:
                     log.warning(f'Sampler: name="{name}" does not support sigma="{sched_sigma}", using default schedule')
         else:
@@ -520,7 +520,7 @@ class DiffusionSampler:
             if debug:
                 errors.display(e, 'Samplers')
             if debug or not shared.opts.schedulers_fallback:
-                raise
+                raise errors.ValidationError(f'Sampler: name="{name}" {e}') from e
             self.sampler = None
             return
 
@@ -529,7 +529,7 @@ class DiffusionSampler:
                 cls_source = inspect.getsource(constructor)
                 if '"flow_prediction"' not in cls_source and "'flow_prediction'" not in cls_source:
                     if debug or not shared.opts.schedulers_fallback:
-                        raise ValueError(f'Sampler: name="{name}" does not appear to support flow_prediction')
+                        raise errors.ValidationError(f'Sampler: name="{name}" does not appear to support flow_prediction')
                     else:
                         log.warning(f'Sampler: name="{name}" does not support flow_prediction')
                         self.sampler = None
@@ -549,7 +549,7 @@ class DiffusionSampler:
             default_accept_sigmas = (model is not None) and hasattr(model.default_scheduler, 'set_timesteps') and "sigmas" in set(inspect.signature(model.default_scheduler.set_timesteps).parameters.keys())
             if default_accept_sigmas and not accept_sigmas:
                 if debug or not shared.opts.schedulers_fallback:
-                    raise ValueError(f'Sampler: name="{name}" does not accept sigmas')
+                    raise errors.ValidationError(f'Sampler: name="{name}" does not accept sigmas')
                 else:
                     log.warning(f'Sampler: name="{name}" does not accept sigmas')
                     self.sampler = None
@@ -559,7 +559,7 @@ class DiffusionSampler:
             if default_accept_scale_noise and not accept_scale_noise:
                 log.warning(f'Sampler: name="{name}" does not implement scale noise')
                 if debug or not shared.opts.schedulers_fallback:
-                    raise ValueError(f'Sampler: name="{name}" does not implement scale noise')
+                    raise errors.ValidationError(f'Sampler: name="{name}" does not implement scale noise')
                 else:
                     log.warning(f'Sampler: name="{name}" does not implement scale noise')
                     self.sampler = None


### PR DESCRIPTION
## Description

Three paths restored the model default regardless of the `schedulers_fallback` setting: prediction-type validation in `create_sampler`, the unknown-sampler-config path, and the catch-all around the scheduler constructor. 

## Notes

- Each now raises when fallback is off, matching the existing gates. 
- `update_sampler` no longer substitutes UniPC for unresolved names, and `find_sampler(None)` resolves to Default instead of UniPC. 
- Validation failures raise errors.ValidationError, which `errors.display()` reports as a single line instead of a backtrace.

## Environment and Testing

- Validated with test/test-samplers-api.py full-matrix runs on SDXL and Flux (both endpoints).
