### PR TITLE
Fix transposed tile dimensions in mixture tiling script

### DIFF
--- a/scripts/mixture_tiling.py
+++ b/scripts/mixture_tiling.py
@@ -74,10 +74,10 @@ class MixtureTilingScript(scripts_manager.Script):
             y_prompts.append(x_prompts)
         p.task_args['prompt'] = y_prompts
         p.task_args['seed'] = p.seed
-        p.task_args['tile_width'] = p.height
-        p.task_args['tile_height'] = p.width
-        p.task_args['tile_col_overlap'] = int(p.height * x_overlap)
-        p.task_args['tile_row_overlap'] = int(p.width * y_overlap)
+        p.task_args['tile_width'] = p.width
+        p.task_args['tile_height'] = p.height
+        p.task_args['tile_col_overlap'] = int(p.width * x_overlap)
+        p.task_args['tile_row_overlap'] = int(p.height * y_overlap)
         p.task_args['output_type'] = 'np'
         # run pipeline
         log.debug(f'Tiling: args={p.task_args}')


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found and verified the bug — the investigation and live repro are documented in #4902. The account owner reviewed a plain-language explanation of the fix and chose to submit.*

## Description

Fixes #4902. `scripts/mixture_tiling.py` cross-assigns all four dimension arguments passed to the community `StableDiffusionTilingPipeline`: `tile_width` was set from `p.height`, `tile_height` from `p.width`, and the column/row overlaps were swapped the same way. The transposition is invisible at the square default (512×512) but produces wrong output geometry for every non-square tile size. This PR assigns the four values to their correct axes.

## Testing

Live before/after on Windows 11 / RTX 5090 (SD1.5, fixed seed, 2×1 grid of 768×512 tiles, full logs and repro images in #4902): stock produced 1024×768 (transposed); with this fix the same request produces the expected 1536×512. The `--debug` `Tiling: args=` line confirms the swapped values at runtime.
