### PR TITLE
Fix assorted small typos: dead __str__, unformatted messages, preview min-height

### DIFF
--- a/modules/generation_parameters_copypaste.py
+++ b/modules/generation_parameters_copypaste.py
@@ -198,7 +198,7 @@ def connect_paste_params_buttons():
     binding: ParamBinding
     for binding in registered_param_bindings:
         if binding.tabname not in paste_fields:
-            debug(f"Not not registered: tab={binding.tabname}")
+            debug(f"Not registered: tab={binding.tabname}")
             continue
         fields: list[tuple[gr.components.Component, str]] = paste_fields[binding.tabname]["fields"]
 

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -125,7 +125,7 @@ class Processed:
     def infotext(self, p: StableDiffusionProcessing, index):
         return create_infotext(p, self.all_prompts, self.all_seeds, self.all_subseeds, comments=[], position_in_batch=index % self.batch_size, iteration=index // self.batch_size)
 
-    def __str___(self):
+    def __str__(self):
         return f'{self.__class__.__name__}: {self.__dict__}'
 
 

--- a/modules/sharpfin/sparse_backend.py
+++ b/modules/sharpfin/sparse_backend.py
@@ -167,7 +167,7 @@ class Matrix(torch.nn.Module):
         if column_indices.dtype == torch.int16:
             if size[0] > max_dim or size[1] > max_dim:
                 raise ValueError(
-                    "Sparse matrix with shape {size} exceeds representable "
+                    f"Sparse matrix with shape {size} exceeds representable "
                     "size with 16-bit indices.")
 
     def validate(self):

--- a/scripts/demofusion.py
+++ b/scripts/demofusion.py
@@ -347,7 +347,7 @@ class DemoFusionSDXLPipeline(DiffusionPipeline, FromSingleFileMixin, LoraLoaderM
 
         # DemoFusion specific checks
         if max(height, width) % 1024 != 0:
-            log.error('DemoFusion: resolution={width}x{height} long side must be divisible by 1024')
+            log.error(f'DemoFusion: resolution={width}x{height} long side must be divisible by 1024')
             return None
 
         if num_images_per_prompt != 1:

--- a/ui/progressBar.ts
+++ b/ui/progressBar.ts
@@ -114,7 +114,7 @@ export function requestProgress(id_task = 'undefined', progressEl = null, galler
     livePreview.appendChild(img);
     img.onload = () => {
       img.style.width = `min(100%, max(${img.naturalWidth}px, 512px))`;
-      parentGallery.style.minHeight = `min(82vh, ${img.naturalWidth}px)`;
+      parentGallery.style.minHeight = `min(82vh, ${img.naturalHeight}px)`;
       parentGallery.style.maxHeight = `min(82vh, ${img.naturalHeight}px)`;
       parentGallery.style.overflow = 'hidden';
     };

--- a/ui/settings.ts
+++ b/ui/settings.ts
@@ -107,7 +107,7 @@ function markIfModified(setting_name, value) {
   tab_nav_indicator.classList.toggle('changed', changed_items.size > 0);
   tab_nav_indicator.classList.toggle('saved', saved.size > 0);
   if (changed_items.size > 0) tab_nav_indicator.title += `click to reset ${changed_items.size} unapplied changes in this tab\n`;
-  if (saved.size > 0) tab_nav_indicator.title += `${saved.size} custom values\n${unsaved.size} default values}`;
+  if (saved.size > 0) tab_nav_indicator.title += `${saved.size} custom values\n${unsaved.size} default values`;
   // TODO why is scroll happening on every change if all pages are visible?
   // elem.scrollIntoView({ behavior: 'smooth', block: 'center' });
 }


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found these bugs while triaging the repo and wrote the fixes and this description. The account owner reviewed plain-language explanations of each fix and chose to submit.*

Six one-line fixes, all verifiable by inspection against current `dev`:

- **`modules/processing.py`** — `Processed.__str___` was misspelled with a third trailing underscore, so Python never dispatched it and `str(Processed)` fell back to the default object repr. Renamed to `__str__`. (Nothing in the codebase currently stringifies a `Processed`, so no log output changes — the intended method just becomes reachable.)
- **`scripts/demofusion.py`** — the "long side must be divisible by 1024" error was missing its `f` prefix, so users got the literal `resolution={width}x{height}` instead of their actual resolution.
- **`modules/sharpfin/sparse_backend.py`** — same: the 16-bit-index overflow `ValueError` printed the literal `{size}` instead of the matrix shape.
- **`modules/generation_parameters_copypaste.py`** — debug message typo "Not not registered".
- **`ui/progressBar.ts`** — the live-preview gallery's `minHeight` was computed from `img.naturalWidth`; the adjacent `maxHeight` line correctly uses `naturalHeight`. For wide images this set `min-height` > `max-height`, which CSS resolves in favor of `min-height`, ballooning the gallery with empty space. Now mirrors the `maxHeight` line.
- **`ui/settings.ts`** — stray `}` rendered at the end of the settings-tab tooltip ("N default values}").
