### PR TITLE
Fix batch list padding in create_infotext corrupting infotext indices

### DIFF
--- a/modules/processing_info.py
+++ b/modules/processing_info.py
@@ -34,19 +34,19 @@ def create_infotext(p: StableDiffusionProcessing, all_prompts=None, all_seeds=No
     if all_subseeds is None:
         all_subseeds = p.all_subseeds or [p.subseed]
     while len(all_prompts) <= index:
-        all_prompts.insert(0, p.prompt)
+        all_prompts.append(p.prompt)
     while len(all_seeds) <= index:
-        all_seeds.insert(0, int(p.seed))
+        all_seeds.append(int(p.seed))
     while len(all_subseeds) <= index:
-        all_subseeds.insert(0, int(p.subseed))
+        all_subseeds.append(int(p.subseed))
     while len(all_negative_prompts) <= index:
-        all_negative_prompts.insert(0, p.negative_prompt)
+        all_negative_prompts.append(p.negative_prompt)
     if p.all_templates is not None:
         while len(p.all_templates) <= index:
-            p.all_templates.insert(0, '')
+            p.all_templates.append('')
     if p.all_negative_templates is not None:
         while len(p.all_negative_templates) <= index:
-            p.all_negative_templates.insert(0, '')
+            p.all_negative_templates.append('')
 
     comment = ', '.join(comments) if comments is not None and type(comments) is list else None
     ops = list(set(p.ops))


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bug while triaging the repo, wrote the fix and this description, and ran the live verification described in Testing below. The account owner reviewed a plain-language explanation of the fix and chose to submit.*

## Description

Fixes per-image metadata corruption when `create_infotext` is called with an index past the end of the prompt/seed lists. The padding loops in `modules/processing_info.py` use `insert(0, ...)`, which shifts existing entries to higher indices — so the requested lookup returns another image's metadata, and because the padding mutates the caller's lists in place, subsequent in-range lookups (save loop, UI re-saves) read shifted data too. Changing the padding to `append` preserves existing indices and resolves out-of-range slots to the current generation state, which is what the code already intends to pad with.

Possibly related: #2385 (saved batch metadata "mixed up" with prompts-from-file while previews stay correct) — the symptom profile matches this mechanism, though that issue doesn't trace a root cause.

## Notes

Padding fires when output images outnumber list entries (multi-output pipelines, script-appended images, scripts building `Processed` with fewer entries than images). All six padded lists are consumed only via positional `[index]` lookups — checked all 22 call sites of `create_infotext` and downstream consumers; nothing depends on front-of-list ordering, so the only behavioral change is that index lookups return what the index math promises.

## Testing

Windows 11, RTX 5090. Verified by invoking the real `create_infotext` directly on a live install (lists covering 2 images, then a consumer lookup at index 3 followed by index 0): before the fix, the index-3 lookup returned image 1's seed/prompt and the in-place padding corrupted the caller's lists so the index-0 lookup then returned the pad values instead of image 0's metadata; after the fix, both lookups return what the index math promises. ruff and pylint pass under repo config (10.00/10 on the file).
