### PR TITLE
Fix prompts-from-file batch save metadata misalignment

### DIFF
--- a/scripts/prompts_from_file.py
+++ b/scripts/prompts_from_file.py
@@ -148,8 +148,8 @@ class PromptsFromFileScript(scripts_manager.Script):
             all_seeds += proc.all_seeds
             all_prompts += proc.all_prompts
             all_negative += proc.all_negative_prompts
-            images += proc.images
-            infotexts += proc.infotexts
+            images += proc.images[proc.index_of_first_image:]
+            infotexts += proc.infotexts[proc.index_of_first_image:]
             if state.interrupted:
                 break
         return get_processed(p, images, p.seed, "", all_prompts=all_prompts, all_seeds=all_seeds, all_negative_prompts=all_negative, infotexts=infotexts)


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which verified the bug live and tested the fix as described below. The account owner reviewed plain-language explanations and chose to submit.*

## Description

Fixes #2385 (the surviving batch case). With Prompts-from-file + batch count > 1 and grids enabled, every manual save from the gallery writes a neighboring image's metadata and filename (the "metadata 2-4-4-4, filenames 2-3-1-1" pattern in the original report), and for the last gallery image the metadata lookup runs past the end of the list. This PR makes the script's combined result line up 1:1 with its metadata so manual saves are correct for every image.

## Notes

Mechanism: each per-line `process_images` result carries its own grid at index 0 (`index_of_first_image=1`), but the script concatenates `proc.images`/`proc.infotexts` grids-included while `all_seeds`/`all_prompts` hold only real images, and the combined `Processed` defaults to `index_of_first_image=0`. Layout for 2 lines × batch count 2: gallery `[grid, img1, img2, grid, img3, img4]`, `infotexts` ×6, `all_seeds`/`all_prompts` ×4. `save_files` (`modules/ui_common.py`) then picks metadata via the single-grid heuristic (`infotexts[i+1] if len(infotexts) > len(all_seeds)`) and filename seed/prompt via `all_seeds[i]`/`all_prompts[i]` — with two interleaved grids, every index is shifted.

The fix slices each per-line result from `proc.index_of_first_image`, so per-line grids never enter the combined result and `images`/`infotexts`/`all_seeds`/`all_prompts` stay 1:1 with the gallery.

One thing to be aware of: per-line grids no longer appear in this script's combined gallery (`grid_save` to disk is unaffected). They seem redundant there — and the alternative, teaching `save_files` about multiple interleaved grids, isn't representable in the `Processed` model, whose single `index_of_first_image` assumes one leading grid.

## Environment and Testing

Windows 11, RTX 5090, Python 3.12, current `dev`. Identical request before/after (txt2img, script `prompts from file`, 2 lines, batch count 2, grids enabled, fixed seed): **before** — `infotexts` count 6 with grid entries at positions 0 and 3 against 4 seeds (the misalignment layout above); **after** — `infotexts` count 4, no grid entries, all lists aligned 1:1, which routes `save_files` down its correct `infotexts[i]` branch for every image and removes the out-of-range case.

Additionally verified end-to-end via a standalone simulation that applies the exact `save_files` selection logic (ui_common.py:163–214) to the live server arrays. Before fix: image 1 is saved with image 2's seed and metadata, image 2 gets a grid's metadata, and the second line's images get the first line's prompt with wrong seeds — matching the original report. After fix: all four slots write correct seed/prompt/metadata.
