### PR TITLE
Fix four small logic errors in modules/processing_helpers.py

### DIFF
--- a/modules/processing_helpers.py
+++ b/modules/processing_helpers.py
@@ -520,7 +520,7 @@ def get_generator(p):
             generator = p.generator
         else:
             try:
-                p.seeds = [seed if seed != -1 else get_fixed_seed(seed) for seed in p.seeds if seed]
+                p.seeds = [seed if seed != -1 else get_fixed_seed(seed) for seed in p.seeds if seed is not None]
                 devices.randn(p.seeds[0])
                 generator = [torch.Generator(generator_device).manual_seed(s) for s in p.seeds]
             except Exception as e:

--- a/modules/processing_helpers.py
+++ b/modules/processing_helpers.py
@@ -427,7 +427,7 @@ def resize_hires(p, latents): # input=latents output=pil if not latent_upscaler 
                     if not torch.is_tensor(latents[i]):
                         log.warning(f'Hires: input[{i}]={type(latents[i])} not tensor')
                         latents[i] = processing_vae.vae_encode(image=latents[i], model=shared.sd_model, vae_type=p.vae_type)
-                    latents = torch.cat(latents, dim=0)
+                latents = torch.cat(latents, dim=0)
             except Exception as e:
                 log.error(f'Hires: prepare latents: {e}')
                 resized = latents

--- a/modules/processing_helpers.py
+++ b/modules/processing_helpers.py
@@ -183,7 +183,7 @@ def slerp(val, lo, hi): # from https://discuss.pytorch.org/t/help-regarding-sler
     dot = (lo_norm * hi_norm).sum(1)
     dot_mean = dot.mean()
     if dot_mean > 0.9999: # simplifies slerp to lerp if vectors are nearly parallel
-        return lo * val + hi * (1 - val)
+        return lo * (1 - val) + hi * val
     if dot_mean < 0.0001: # also simplifies slerp to lerp to avoid division-by-zero later on
         return lo * (1.0 - val) + hi * val
     omega = torch.acos(dot)

--- a/modules/processing_helpers.py
+++ b/modules/processing_helpers.py
@@ -202,7 +202,7 @@ def slerp_alt(val, lo, hi): # from https://discuss.pytorch.org/t/help-regarding-
     dot = (lo_norm * hi_norm).sum(1)
     dot_mean = dot.mean().abs()
     if dot_mean > 0.9999: # simplifies slerp to lerp if vectors are nearly parallel
-        lerp_val = lo * val + hi * (1 - val)
+        lerp_val = lo * (1 - val) + hi * val
         return lerp_val / torch.linalg.norm(lerp_val) * torch.sqrt(torch.linalg.norm(hi_norm) * torch.linalg.norm(lo_norm))
     if dot_mean < 0.0001: # also simplifies slerp to lerp to avoid division-by-zero later on
         lerp_val = lo * (1.0 - val) + hi * val


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all four are verifiable by inspection against current dev. The account owner reviewed a plain-language explanation of each fix and chose to submit.*

## Description

Four small, independent logic fixes in `modules/processing_helpers.py`, one commit each:

1. **`resize_hires`: `torch.cat` ran inside the per-item loop.** The `latents = torch.cat(latents, dim=0)` call was indented inside `for i in range(len(latents))`, so on the first iteration the list was replaced by a tensor and subsequent iterations indexed/concatenated the tensor's dim-0 slices instead of list elements — corrupting hires latent input whenever batch size > 1. Dedented one level to run after the loop. Batch size 1 behavior is unchanged (loop ran once either way).

2. **`get_generator`: seed `0` silently dropped.** The comprehension filter `... for seed in p.seeds if seed` is a truthiness test, so a valid seed of `0` was removed from `p.seeds`, causing an empty seeds list or a batch-length mismatch. Changed to `if seed is not None`; `-1` is already handled by the `seed != -1 else get_fixed_seed(seed)` expression in the same comprehension, so the truthiness guard's only effect was the 0-drop.

3. **`slerp`: near-parallel shortcut interpolated in the wrong direction.** The `dot_mean > 0.9999` fast path returned `lo * val + hi * (1 - val)` — at `val=0` it returns `hi`, opposite to both the near-orthogonal shortcut two lines below (`lo * (1.0 - val) + hi * val`) and the general slerp path (`sin((1-val)*omega)` weighting `lo`). Swapped to match. Used for subseed/variation-strength noise blending, so the wrong-direction blend applied exactly when base and variation noise happened to be nearly parallel.

4. **`slerp_alt`: same inversion**, same fix, so the two siblings stay consistent.

## Notes

- All four are one-line changes (the first is a one-line dedent).
- Fixes 3/4 do change output where the near-parallel fast path triggers, but only to make the shortcut agree with the function's own general path — i.e. with what the non-shortcut math already produces at `dot_mean = 0.9999 - ε`.

## Environment and Testing

- Verified by inspection against current `dev`; each bug is a static logic fault (wrong indentation level, truthiness filter dropping a falsy-but-valid value, interpolation weights inverted relative to every other path in the same function).
- Not live-tested in this submission.
