### PR TITLE
Fix XYZ grid state leaks and sub-grid gallery leak

### DIFF
--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -251,6 +251,7 @@ class XYZGridScript(scripts_manager.Script):
         except Exception as e:
             log.error(f"XYZ grid: invalid axis values {e}")
             errors.display(e, 'xyz')
+            shared.state.end(jobid)
             return None
 
         Image.MAX_IMAGE_PIXELS = None # disable check in Pillow and rely on check below to allow large custom image sizes

--- a/scripts/xyz_grid.py
+++ b/scripts/xyz_grid.py
@@ -393,7 +393,7 @@ class XYZGridScript(scripts_manager.Script):
             return processed # something broke, no further handling needed.
 
         have_grid = 1 if include_grid else 0
-        have_subgrids = len(zs) if len(zs) > 1 and include_subgrids else 0
+        have_subgrids = len(zs) if len(zs) > 1 and (include_grid or include_subgrids) else 0 # sub-grids are created whenever the main grid is, see draw_xyz_grid
         have_images = processed.images[have_grid+have_subgrids:]
         processed.infotexts[:have_grid+have_subgrids] = grid_infotext[:have_grid+have_subgrids] # update infotexts with grid and subgrid info
         log.debug(f'XYZ grid: grid={have_grid} subgrids={have_subgrids} images={len(have_images)} total={len(processed.images)}')

--- a/scripts/xyz_grid_on.py
+++ b/scripts/xyz_grid_on.py
@@ -267,6 +267,7 @@ class XYZGridScript(scripts_manager.Script):
         except Exception as e:
             log.error(f"XYZ grid: invalid axis values {e}")
             errors.display(e, 'xyz')
+            active = False
             return None
 
         Image.MAX_IMAGE_PIXELS = None # disable check in Pillow and rely on check below to allow large custom image sizes

--- a/scripts/xyz_grid_on.py
+++ b/scripts/xyz_grid_on.py
@@ -422,7 +422,7 @@ class XYZGridScript(scripts_manager.Script):
             return processed # something broke, no further handling needed.
 
         have_grid = 1 if include_grid else 0
-        have_subgrids = len(zs) if len(zs) > 1 and include_subgrids else 0
+        have_subgrids = len(zs) if len(zs) > 1 and (include_grid or include_subgrids) else 0 # sub-grids are created whenever the main grid is, see draw_xyz_grid
         have_images = processed.images[have_grid+have_subgrids:]
         processed.infotexts[:have_grid+have_subgrids] = grid_infotext[:have_grid+have_subgrids] # update infotexts with grid and subgrid info
         log.debug(f'XYZ grid: grid={have_grid} subgrids={have_subgrids} images={len(have_images)} total={len(processed.images)}')

--- a/scripts/xyz_grid_on.py
+++ b/scripts/xyz_grid_on.py
@@ -268,6 +268,7 @@ class XYZGridScript(scripts_manager.Script):
             log.error(f"XYZ grid: invalid axis values {e}")
             errors.display(e, 'xyz')
             active = False
+            shared.state.end(jobid)
             return None
 
         Image.MAX_IMAGE_PIXELS = None # disable check in Pillow and rely on check below to allow large custom image sizes


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all are verifiable by inspection against current dev. The account owner chose to submit based on Claude's analysis.*

## Description

Three related state/cleanup fixes in the XYZ grid scripts:

1. **Error path leaves XYZ grid permanently disabled** (`xyz_grid_on.py`): the module-level `active` flag is set `True` at the top of `run()`, and the early-return guard `if not enabled or active: return None` means any later run is skipped while it's set. The axis-parse `except` path returned without resetting it, so one invalid axis value silently disabled the XYZ grid until process restart. Added `active = False` on that path.
2. **Error path leaks the job state** (`xyz_grid.py` and `xyz_grid_on.py`): `jobid = shared.state.begin('XYZ Grid')` runs before the axis-parse try block, but the `except` path returned without `shared.state.end(jobid)`, leaving the job tracker open. Added the `end()` call on both scripts' error paths, mirroring their normal-path cleanup.
3. **Sub-grids leak into the gallery when only the main grid is requested** (both scripts): `draw_xyz_grid` inserts Z sub-grids whenever `include_grid or include_subgrids` is true, but the cleanup code counted them with `have_subgrids = len(zs) if len(zs) > 1 and include_subgrids else 0` — so with "Include main grid" on and "Include sub grids" off, the inserted sub-grids were never counted, leaked into `have_images`, misaligned infotexts, and fed video creation; the removal branch below it was unreachable. Changed the count condition to `include_grid or include_subgrids` to mirror the insertion condition.

## Notes

- 4 changed lines + 2 inserted lines total, across the two XYZ scripts.
- Each fix mirrors an existing correct pattern in the same file (the normal-path cleanup, the `draw_xyz_grid` insertion condition).

## Environment and Testing

- Verified by inspection against current `dev`: the leaked flag/job are set before the try block and provably not cleared on the except path; the sub-grid count condition provably disagrees with the insertion condition.
- Not live-tested in this submission.
