### PR TITLE
Fix compel prompt guard duplicate clause and PObject infotext key mismatches

### DIFF
--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -322,7 +322,7 @@ def parse_prompt_attention(text):
         return res
     elif opts.prompt_attention == 'compel':
         conjunction = Compel.parse_prompt_string(text)
-        if conjunction is None or conjunction.prompts is None or conjunction.prompts is None or len(conjunction.prompts[0].children) == 0:
+        if conjunction is None or conjunction.prompts is None or len(conjunction.prompts) == 0 or len(conjunction.prompts[0].children) == 0:
             return [["", 1.0]]
         res = []
         for frag in conjunction.prompts[0].children:

--- a/modules/ui_common.py
+++ b/modules/ui_common.py
@@ -145,7 +145,7 @@ def save_files(js_data, files, html_info, index):
                 for k, v in d.items():
                     setattr(self, k, v)
             self.prompt = getattr(self, 'prompt', None) or getattr(self, 'Prompt', None) or ''
-            self.negative_prompt = getattr(self, 'negative_prompt', None) or getattr(self, 'Negative_prompt', None) or ''
+            self.negative_prompt = getattr(self, 'negative_prompt', None) or getattr(self, 'Negative prompt', None) or ''
             self.sampler = getattr(self, 'sampler', None) or getattr(self, 'Sampler', None) or ''
             self.sampler_name = self.sampler
             self.seed = getattr(self, 'seed', None) or getattr(self, 'Seed', None) or 0
@@ -156,7 +156,7 @@ def save_files(js_data, files, html_info, index):
             self.clip_skip = getattr(self, 'clip_skip', None) or getattr(self, 'CLiP-skip', None) or 1
             self.denoising_strength = getattr(self, 'denoising_strength', None) or getattr(self, 'Denoising', None) or 0
             self.index_of_first_image = getattr(self, 'index_of_first_image', 0)
-            self.subseed = getattr(self, 'subseed', None) or getattr(self, 'Subseed', None)
+            self.subseed = getattr(self, 'subseed', None) or getattr(self, 'Variation seed', None)
             self.styles = getattr(self, 'styles', None) or getattr(self, 'Styles', None) or []
             self.styles = [s.strip() for s in self.styles.split(',')] if isinstance(self.styles, str) else self.styles
 


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; both are verifiable by inspection against current dev. The account owner chose to submit based on Claude's analysis.*

## Description

Two small metadata/parsing correctness fixes:

1. **`modules/prompt_parser.py`: duplicated guard clause.** The compel-path guard reads `if conjunction is None or conjunction.prompts is None or conjunction.prompts is None or len(conjunction.prompts[0].children) == 0:` — the second `conjunction.prompts is None` is a duplicate, evidently meant to be the empty-list check. With `conjunction.prompts == []`, the final clause indexes `prompts[0]` and raises `IndexError`. Replaced the duplicate with `len(conjunction.prompts) == 0`.
2. **`modules/ui_common.py`: `PObject` fallback keys never match.** The fallback lookups use `getattr(self, 'Negative_prompt', None)` and `getattr(self, 'Subseed', None)`, but the infotext parser produces the keys `Negative prompt` (space) and `Variation seed`. The fallbacks therefore never resolve and the values silently drop. Changed to the parser's actual key names (the sibling `CFG scale` lookup on the same block already uses the spaced form).

## Notes

- 3 changed lines total, no behavior change outside the broken paths.

## Environment and Testing

- Verified by inspection against current `dev`: the duplicate clause is verbatim on dev; the parser's emitted key names (`Negative prompt`, `Variation seed`) are confirmed in `modules/processing_info.py` / `modules/infotext.py`.
- Not live-tested in this submission.
