### PR TITLE
Fix four small bugs in upscale and postprocess paths

### DIFF
--- a/modules/image/resize.py
+++ b/modules/image/resize.py
@@ -51,7 +51,7 @@ def resize_image(resize_mode: int, im: Image.Image | torch.Tensor, width: int, h
                 else:
                     im = selected_upscaler.scaler.upscale(im, scale, selected_upscaler.name)
             else:
-                log.warning(f"Resize upscaler: invalid={upscaler_name} fallback={selected_upscaler.name}")
+                log.warning(f"Resize upscaler: invalid={upscaler_name} fallback=resample")
                 log.debug(f"Resize upscaler: available={[u.name for u in shared.sd_upscalers]}")
         if isinstance(im, Image.Image) and (im.width != w or im.height != h): # probably downsample after upscaler created larger image
             im = sharpfin.resize(im, (w, h))

--- a/scripts/postprocessing_rembg.py
+++ b/scripts/postprocessing_rembg.py
@@ -98,14 +98,13 @@ class ScriptPostprocessingRembg(scripts_postprocessing.ScriptPostprocessing):
                 log.error(f'RemoveBackground: model={model} {e}')
                 return pp
 
-        if mask_only and pp.image.mode == "RGBA":
-            _r, _g, _b, alpha = pp.image.split()
+        if mask_only and image.mode == "RGBA":
+            _r, _g, _b, alpha = image.split()
             image = alpha
-        if merge_alpha and pp.image.mode == "RGBA":
-            flattened = Image.new("RGBA", pp.image.size, "BLACK")
-            flattened.paste(pp.image, mask=pp.image)
-            flattened.convert("RGB")
-            image = flattened
+        if merge_alpha and image.mode == "RGBA":
+            flattened = Image.new("RGBA", image.size, "BLACK")
+            flattened.paste(image, mask=image)
+            image = flattened.convert("RGB")
 
         if isinstance(pp, Image.Image):
             pp = scripts_postprocessing.PostprocessedImage(image=image, info={**info, "Rembg": model})

--- a/scripts/postprocessing_upscale.py
+++ b/scripts/postprocessing_upscale.py
@@ -112,5 +112,6 @@ class ScriptPostprocessingUpscaleSimple(ScriptPostprocessingUpscale):
         upscaler1 = next(iter([x for x in shared.sd_upscalers if x.name == upscaler_name]), None)
         if upscaler1 is None:
             log.debug(f"Upscaler not found: {upscaler_name}")
+            return
         pp.image = self.upscale(pp.image, pp.info, upscaler1, 0, upscale_by, 0, 0, False)
         pp.info["Postprocess upscaler"] = upscaler1.name

--- a/scripts/sd_upscale.py
+++ b/scripts/sd_upscale.py
@@ -29,7 +29,7 @@ class SDUpscaleScript(scripts_manager.Script):
         init_img = None
         if hasattr(p, 'init_images') and p.init_images is not None:
             init_img = p.init_images[0]
-        elif hasattr(p.task_args, 'image') and p.task_args['image'] is not None:
+        elif p.task_args.get('image', None) is not None:
             init_img = p.task_args['image'][0]
 
         if init_img is None:


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all four are verifiable by inspection against current dev. The account owner chose to submit based on Claude's analysis.*

## Description

Four independent fixes, one commit each:

1. **`scripts/postprocessing_upscale.py`: Simple-upscale crash on unknown upscaler name.** `ScriptPostprocessingUpscaleSimple.process()` logs "Upscaler not found" but falls through and calls `self.upscale()` with `upscaler1 = None` (then `upscaler1.name`) → `AttributeError`. Added the early `return` the parent class already has on the same condition.
2. **`modules/image/resize.py`: `UnboundLocalError` on invalid upscaler name.** The not-found warning interpolates `selected_upscaler.name`, but `selected_upscaler` is only assigned in the other branch — the warning itself crashes instead of falling back. Changed the message to reference the resample fallback.
3. **`scripts/sd_upscale.py`: dead `task_args` image fallback.** `hasattr(p.task_args, 'image')` checks for an attribute on a dict, which is always false, so images passed via `task_args` were ignored. Changed to `p.task_args.get('image', None) is not None`.
4. **`scripts/postprocessing_rembg.py`: mask-only / merge-alpha options inspect the wrong image.** Both options check `pp.image` (the pre-rembg input, normally RGB) instead of the RGBA rembg output, making both branches dead in normal use; additionally `flattened.convert("RGB")`'s return value was discarded (PIL returns a new image). Pointed both options at the rembg output and captured the conversion result.

## Notes

- 9 insertions / 9 deletions across four files; each fix is independent.

## Environment and Testing

- Verified by inspection against current `dev`: each is a static fault (missing return present in the sibling class, unbound variable in the logging branch, `hasattr` on a dict, wrong variable + discarded return value).
- Not live-tested in this submission.
