### PR TITLE
Fix seven small bugs in script extensions

### DIFF
--- a/modules/scripts_manager.py
+++ b/modules/scripts_manager.py
@@ -345,8 +345,9 @@ class ScriptSummary:
         self.time = {}
 
     def record(self, script):
-        self.update = time.time()
-        self.time[script] = round(time.time() - self.update, 2)
+        now = time.time()
+        self.time[script] = round(now - self.update, 2)
+        self.update = now
 
     def report(self):
         total = sum(self.time.values())

--- a/scripts/animatediff.py
+++ b/scripts/animatediff.py
@@ -47,12 +47,12 @@ def set_adapter(adapter_name: str = 'None'):
     global motion_adapter, loaded_adapter, orig_pipe # pylint: disable=global-statement
     # adapter_name = name if name is not None and isinstance(name, str) else loaded_adapter
     if adapter_name is None or adapter_name == 'None' or not shared.sd_loaded:
-        motion_adapter = None
-        loaded_adapter = None
         if orig_pipe is not None:
             log.debug(f'AnimateDiff restore pipeline: adapter="{loaded_adapter}"')
             shared.sd_model = orig_pipe
             orig_pipe = None
+        motion_adapter = None
+        loaded_adapter = None
         return
     if shared.sd_model_type != 'sd' and shared.sd_model_type != 'sdxl' and not (shared.sd_model.__class__.__name__ == 'AnimateDiffPipeline' or shared.sd_model.__class__.__name__ == 'AnimateDiffSDXLPipeline'):
         log.warning(f'AnimateDiff: unsupported model type: {shared.sd_model.__class__.__name__}')
@@ -133,7 +133,7 @@ def set_adapter(adapter_name: str = 'None'):
         loaded_adapter = None
         log.error(f'AnimateDiff load error: adapter="{adapter_name}" {e}')
         from modules import errors
-        errors.display('e', 'AnimateDiff')
+        errors.display(e, 'AnimateDiff')
 
 
 def set_scheduler(p, model, override: bool = False):

--- a/scripts/consistory_ext.py
+++ b/scripts/consistory_ext.py
@@ -95,10 +95,10 @@ class ConsiStoryScript(scripts_manager.Script):
             try:
                 freeu_preset = [float(f.strip()) for f in freeu_preset.split(',')]
             except Exception:
-                freeu_preset = []
                 log.warning(f'ConsiStory: freeu="{freeu_preset}" invalid')
-            if len(freeu) == 4:
-                shared.sd_model.enable_freeu(s1=freeu[0], s2=freeu[0], b1=freeu[0], b2=freeu[0])
+                freeu_preset = []
+            if len(freeu_preset) == 4:
+                shared.sd_model.enable_freeu(s1=freeu_preset[0], s2=freeu_preset[1], b1=freeu_preset[2], b2=freeu_preset[3])
         steps = 50 if steps else p.steps
         if injection:
             try:

--- a/scripts/ipinstruct.py
+++ b/scripts/ipinstruct.py
@@ -106,7 +106,7 @@ class IPInstructScript(scripts_manager.Script):
         # p.extra_generation_params["IPInstruct"] = f''
         return processed
 
-    def after(self, p: processing.StableDiffusionProcessing, processed: processing.Processed, **kwargs): # pylint: disable=unused-argument
+    def after(self, p: processing.StableDiffusionProcessing, processed: processing.Processed, *args): # pylint: disable=unused-argument
         if self.orig_pipe is not None:
             shared.sd_model = self.orig_pipe
         return processed

--- a/scripts/lbm_ext.py
+++ b/scripts/lbm_ext.py
@@ -131,7 +131,7 @@ class LBMScript(scripts_manager.Script):
             model.to(device=devices.cpu)
 
         if output_image is not None:
-            output_image.resize((ori_h_bg, ori_w_bg))
+            output_image = output_image.resize((ori_h_bg, ori_w_bg))
             return processing.get_processed(p, [output_image])
         else:
             return processing.Processed(p, [])

--- a/scripts/mulan.py
+++ b/scripts/mulan.py
@@ -93,7 +93,7 @@ class MuLanScript(scripts_manager.Script):
             p.prompt = p.prompt[0]
         p.task_args['prompt'] = p.prompt
         if isinstance(p.negative_prompt, list):
-            p.prompt = p.negative_prompt[0]
+            p.negative_prompt = p.negative_prompt[0]
         p.task_args['negative_prompt'] = p.negative_prompt
 
         if pipe_type != ('sd15' if shared.sd_model_type == 'sd' else 'sdxl'):

--- a/scripts/pixelsmith_ext.py
+++ b/scripts/pixelsmith_ext.py
@@ -46,6 +46,7 @@ class PixelSmithScript(scripts_manager.Script):
         supported_model_list = ['sdxl']
         if shared.sd_model_type not in supported_model_list:
             log.warning(f'PixelSmith: class={shared.sd_model.__class__.__name__} model={shared.sd_model_type} required={supported_model_list}')
+            return None
         from scripts.pixelsmith import PixelSmithXLPipeline, PixelSmithVAE # pylint: disable=no-name-in-module
         self.orig_pipe = shared.sd_model
         self.orig_vae = shared.sd_model.vae


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all are verifiable by inspection against current dev. The account owner chose to submit based on Claude's analysis.*

## Description

Seven independent one-to-few-line fixes in `scripts/` (plus one in `modules/scripts_manager.py`), one commit each:

1. **`pixelsmith_ext.py`**: the unsupported-model warning has no `return`, so the script proceeded to swap `shared.sd_model` and the VAE on a non-SDXL model anyway. Added `return None` — the same guard all six sibling scripts with this pattern already have.
2. **`ipinstruct.py`**: `after()` is declared with `**kwargs` but `scripts_manager` calls it positionally (`script.after(p, processed, *parsed)`) → `TypeError` on every run, pipeline never restored. Changed to `*args`, matching every sibling script.
3. **`mulan.py`**: the negative-prompt list unwrap assigns to `p.prompt` instead of `p.negative_prompt`, clobbering the positive prompt and passing an unsupported list to the pipeline.
4. **`consistory_ext.py`**: FreeU enable path calls `len(freeu)` on a checkbox bool → `TypeError`; all four FreeU parameters were fed `freeu[0]`; the invalid-preset warning logged after the value was already cleared. Now guards on the parsed `freeu_preset` list, passes its four values, and logs before clearing.
5. **`lbm_ext.py`**: PIL `Image.resize()` returns a new image; the result was discarded, so the output was never restored to the input dimensions. Assigned the result back.
6. **`animatediff.py`**: `errors.display('e', …)` passed the literal string `'e'` instead of the caught exception (discarding the traceback), and `loaded_adapter` was nulled before the restore log line that prints it (always logging `None`). Pass the exception object; reorder the nulling.
7. **`modules/scripts_manager.py`**: `ScriptSummary.record()` reset `self.update` to now immediately before subtracting it from now, so every script's recorded time was ~0 and `report()` (total == 0) never logged. Standard lap-timer order: compute the delta against the old reference, then advance it.

## Notes

- All independent; one commit per fix for easy partial revert/cherry-pick.
- 13 insertions / 11 deletions across 7 files.

## Environment and Testing

- Verified by inspection against current `dev`; each is a static logic fault (missing return, wrong call signature vs the call site, wrong assignment target, `len()` on a bool, discarded return value, literal `'e'` vs the exception, clobbered timer reference).
- Not live-tested in this submission.
