### PR TITLE
Fix FreeScale early-return state corruption and stage resolution rounding

### DIFF
--- a/scripts/freescale_ext.py
+++ b/scripts/freescale_ext.py
@@ -90,6 +90,10 @@ class FreeScaleScript(scripts_manager.Script):
             resolutions_list.append(scale(s4_scale))
             restart_steps.append(int(p.steps * s4_restart))
 
+        if p.width < 1024 or p.height < 1024:
+            log.error(f'FreeScale: width={p.width} height={p.height} minimum=1024')
+            return None
+
         p.task_args['resolutions_list'] = resolutions_list
         p.task_args['cosine_scale'] = cosine_scale
         p.task_args['restart_steps'] = [min(max(1, step), p.steps-1) for step in restart_steps]
@@ -100,10 +104,6 @@ class FreeScaleScript(scripts_manager.Script):
             p.init_images = None
         if override_sampler:
             p.sampler_name = 'Euler a'
-
-        if p.width < 1024 or p.height < 1024:
-            log.error(f'FreeScale: width={p.width} height={p.height} minimum=1024')
-            return None
 
         if not self.is_img2img:
             shared.sd_model = sd_models.switch_pipe(StableDiffusionXLFreeScale, shared.sd_model)

--- a/scripts/freescale_ext.py
+++ b/scripts/freescale_ext.py
@@ -67,7 +67,7 @@ class FreeScaleScript(scripts_manager.Script):
         def scale(x):
             if (p.width == 0 or p.height == 0) and p.init_images is not None:
                 p.width, p.height = p.init_images[0].width, p.init_images[0].height
-            resolution = [int(8 * p.width * x // 8), int(8 * p.height * x // 8)]
+            resolution = [8 * int(p.width * x // 8), 8 * int(p.height * x // 8)]
             return resolution
 
         scales = []


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; both are verifiable by inspection against current dev. The account owner chose to submit based on Claude's analysis.*

## Description

Two fixes in `scripts/freescale_ext.py`:

1. **Sub-1024 rejection runs after the processing object is already modified.** The resolution check (`return None`, falling back to normal processing) executed after `p.init_images` was nulled, FreeScale-specific `task_args` injected, and the sampler overridden — so the fallback ran on a corrupted processing object. Moved the guard before any mutation.
2. **Stage resolutions not snapped to a multiple of 8.** The expression `int(8 * p.width * x // 8)` lets the `* 8` and `// 8` cancel (it equals `int(p.width * x)`), so fractional scale factors could produce dimensions not divisible by 8. Changed to `8 * int(p.width * x // 8)`.

## Notes

- A pure statement reorder plus a one-line arithmetic fix.

## Environment and Testing

- Verified by inspection against current `dev`: the statement order and the operator-precedence cancellation are readable directly from the source.
- Not live-tested in this submission.
