### PR TITLE
Fix dead init_images branch, dead timer profile mode, and empty-list crashes in processing

### DIFF
--- a/modules/processing_args.py
+++ b/modules/processing_args.py
@@ -159,8 +159,8 @@ def task_specific_kwargs(p, model):
             return task_args
         task_args = {
             'reference_image': p.init_images[0],
-            'source_subject_category': getattr(p, 'negative_prompt', '').split()[-1],
-            'target_subject_category': getattr(p, 'prompt', '').split()[-1],
+            'source_subject_category': (getattr(p, 'negative_prompt', '').split() or [''])[-1],
+            'target_subject_category': (getattr(p, 'prompt', '').split() or [''])[-1],
             'output_type': 'pil',
         }
 

--- a/modules/processing_prompt.py
+++ b/modules/processing_prompt.py
@@ -23,21 +23,21 @@ def fix_prompt_batch(p, prompts, negative_prompts, prompts_2, negative_prompts_2
     if type(negative_prompts) is str:
         negative_prompts = [negative_prompts]
 
-    if hasattr(p, '[init_images]') and p.init_images is not None and len(p.init_images) > 1:
+    if hasattr(p, 'init_images') and p.init_images is not None and len(p.init_images) > 1:
         while len(prompts) < len(p.init_images):
-            prompts.append(prompts[-1])
+            prompts.append(prompts[-1] if prompts else '')
         while len(negative_prompts) < len(p.init_images):
-            negative_prompts.append(negative_prompts[-1])
+            negative_prompts.append(negative_prompts[-1] if negative_prompts else '')
 
     while len(prompts) < p.batch_size:
-        prompts.append(prompts[-1])
+        prompts.append(prompts[-1] if prompts else '')
     while len(negative_prompts) < p.batch_size:
-        negative_prompts.append(negative_prompts[-1])
+        negative_prompts.append(negative_prompts[-1] if negative_prompts else '')
 
     while len(negative_prompts) < len(prompts):
-        negative_prompts.append(negative_prompts[-1])
+        negative_prompts.append(negative_prompts[-1] if negative_prompts else '')
     while len(prompts) < len(negative_prompts):
-        prompts.append(prompts[-1])
+        prompts.append(prompts[-1] if prompts else '')
 
     if type(prompts_2) is str:
         prompts_2 = [prompts_2]

--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -270,6 +270,8 @@ def reconstruct_multicond_batch(c: MulticondLearnedConditioning, current_step):
             tensors.append(composable_prompt.schedules[target_index].cond)
         conds_list.append(conds_for_batch)
     # if prompts have wildly different lengths above the limit we'll get tensors of different shapes and won't be able to torch.stack them. So this fixes that.
+    if not tensors:
+        return conds_list, torch.zeros([0], device=param.device, dtype=param.dtype)
     token_count = max([x.shape[0] for x in tensors])
     for i in range(len(tensors)):
         if tensors[i].shape[0] != token_count:

--- a/modules/scripts_postprocessing.py
+++ b/modules/scripts_postprocessing.py
@@ -134,7 +134,7 @@ class ScriptPostprocessingRunner:
             with gr.Blocks(analytics_enabled=False):
                 self.setup_ui()
         scripts = self.scripts_in_preferred_order()
-        args = [None] * max([x.args_to for x in scripts])
+        args = [None] * max([x.args_to for x in scripts], default=0)
         for script in scripts:
             script_args_dict = scripts_args.get(script.name, None)
             if script_args_dict is not None:

--- a/modules/timer.py
+++ b/modules/timer.py
@@ -59,11 +59,12 @@ class Timer:
         return sum(self.records.values())
 
     def dct(self, min_time=default_min_time):
-        if self.profile:
-            res = {k: round(v, 4) for k, v in self.records.items()}
         self.total = sum(self.records.values())
         self.records['total'] = self.total
-        res = {k: round(v, 2) for k, v in self.records.items() if v >= min_time}
+        if self.profile:
+            res = {k: round(v, 4) for k, v in self.records.items()}
+        else:
+            res = {k: round(v, 2) for k, v in self.records.items() if v >= min_time}
         res = {k: v for k, v in sorted(res.items(), key=lambda x: x[1], reverse=True)} # noqa: C416 # pylint: disable=unnecessary-comprehension
         return res
 


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all are verifiable by inspection against current dev and the final diffs passed an independent adversarial review. The account owner chose to submit based on Claude's analysis.*

- `processing_prompt.py`: `hasattr(p, '[init_images]')` with the bracketed string literal is never a real attribute, so the multi-image prompt-padding branch was dead; fixed to `'init_images'`. Also guarded the `prompts[-1]`/`negative_prompts[-1]` while-loops against empty lists
- `processing_args.py`: BLiP path IndexError on empty prompt/negative prompt
- `prompt_parser.py`: `max()` over empty tensors list (ValueError); early return for empty batch
- `scripts_postprocessing.py`: `max()` over empty list when no postprocessing scripts are loaded
- `timer.py`: the `self.profile` branch assigned `res` and was immediately overwritten by the unconditional assignment below, so profile mode was dead; restructured to if/else

