### PR TITLE
Fix wrong-variable checks in TE/quant loading and remote-VAE response handling

### DIFF
--- a/modules/lora/lora_load.py
+++ b/modules/lora/lora_load.py
@@ -98,9 +98,11 @@ def load_safetensors(name, network_on_disk: network.NetworkOnDisk) -> network.Ne
             continue
         if parts[0] in ["clip_l","clip_g","t5","unet","transformer"]:
             network_part = []
-            while parts[-1] in ["alpha","weight","lora_up","lora_down"]:
+            while parts and parts[-1] in ["alpha","weight","lora_up","lora_down"]:
                 network_part.insert(0,parts[-1])
                 parts = parts[0:-1]
+            if not parts:
+                continue
             network_part = ".".join(network_part)
             key_network_without_network_parts = "_".join(parts)
             if key_network_without_network_parts.startswith("unet") or key_network_without_network_parts.startswith("transformer"):

--- a/modules/memstats.py
+++ b/modules/memstats.py
@@ -54,7 +54,11 @@ def ram_stats():
         res = process.memory_info()
         if 'total' not in ram:
             process = psutil.Process(os.getpid())
-            ram_total = 100 * res.rss / process.memory_percent()
+            mem_percent = process.memory_percent()
+            if mem_percent > 0:
+                ram_total = 100 * res.rss / mem_percent
+            else:
+                ram_total = res.rss
             ram_total = min(ram_total, get_docker_limit(), get_runpod_limit())
             ram['total'] = gb(ram_total)
         ram['rss'] = gb(res.rss)

--- a/modules/merging/modules_sdxl.py
+++ b/modules/merging/modules_sdxl.py
@@ -251,7 +251,7 @@ def get_metadata():
         "modelspec.license": recipe.license,
         "modelspec.usage_hint": recipe.hint,
         "modelspec.prediction_type": recipe.prediction,
-        "modelspec.dtype": str(recipe.dtype).split('.')[1],
+        "modelspec.dtype": str(recipe.dtype).split('.')[-1] if '.' in str(recipe.dtype) else str(recipe.dtype),
         "modelspec.hash_sha256": "",
         "modelspec.thumbnail": get_thumbnail(),
         "recipe": json.dumps({

--- a/modules/model_quant.py
+++ b/modules/model_quant.py
@@ -445,7 +445,13 @@ def sdnq_quantize_model(model, op=None, sd_model=None, do_gc: bool = True, weigh
         if quant_last_model_name is not None:
             if "." in quant_last_model_name:
                 last_model_names = quant_last_model_name.split(".")
-                getattr(getattr(sd_model, last_model_names[0]), last_model_names[1]).to(quant_last_model_device)
+                if len(last_model_names) >= 2:
+                    try:
+                        parent = getattr(sd_model, last_model_names[0], None)
+                        if parent is not None:
+                            getattr(parent, last_model_names[1]).to(quant_last_model_device)
+                    except (AttributeError, TypeError):
+                        log.warning(f'Quantization: failed to access {quant_last_model_name}')
             else:
                 getattr(sd_model, quant_last_model_name).to(quant_last_model_device)
             if do_gc:
@@ -479,7 +485,13 @@ def sdnq_quantize_weights(sd_model):
         if quant_last_model_name is not None:
             if "." in quant_last_model_name:
                 last_model_names = quant_last_model_name.split(".")
-                getattr(getattr(sd_model, last_model_names[0]), last_model_names[1]).to(quant_last_model_device)
+                if len(last_model_names) >= 2:
+                    try:
+                        parent = getattr(sd_model, last_model_names[0], None)
+                        if parent is not None:
+                            getattr(parent, last_model_names[1]).to(quant_last_model_device)
+                    except (AttributeError, TypeError):
+                        log.warning(f'Quantization: failed to access {quant_last_model_name}')
             else:
                 getattr(sd_model, quant_last_model_name).to(quant_last_model_device)
             devices.torch_gc(force=True, reason='sdnq')

--- a/modules/model_te.py
+++ b/modules/model_te.py
@@ -77,7 +77,7 @@ def load_t5(name=None, cache_dir=None):
     elif '/' in name:
         log.debug(f'Load model: type=T5 repo={name}')
         quant_config = model_quant.create_config(module='TE')
-        if quantization_config is not None:
+        if quant_config is not None:
             t5 = transformers.T5EncoderModel.from_pretrained(name, cache_dir=cache_dir, torch_dtype=devices.dtype, **quant_config)
 
     else:

--- a/modules/vae/sd_vae_remote.py
+++ b/modules/vae/sd_vae_remote.py
@@ -64,9 +64,9 @@ def remote_decode(latents: torch.Tensor, width: int = 0, height: int = 0, model_
     t0 = time.time()
     modelloader.hf_login()
     latent_copy = latents.detach().clone().to(device=devices.cpu, dtype=devices.dtype)
-    latent_copy = latents.unsqueeze(0) if len(latents.shape) == 3 else latents
+    latent_copy = latent_copy.unsqueeze(0) if len(latent_copy.shape) == 3 else latent_copy
     if model_type == 'hunyuanvideo':
-        latent_copy = latent_copy.unsqueeze(0) if len(latents.shape) == 4 else latents
+        latent_copy = latent_copy.unsqueeze(0) if len(latent_copy.shape) == 4 else latent_copy
 
     for i in range(latent_copy.shape[0]):
         params = {}
@@ -112,13 +112,25 @@ def remote_decode(latents: torch.Tensor, width: int = 0, height: int = 0, model_
                 timeout=300,
             )
             if not response.ok:
-                log.error(f'Decode: type="remote" model={model_type} code={response.status_code} shape={latent.shape} url="{url}" args={params} headers={response.headers} response={response.json()}')
+                try:
+                    resp_json = response.json()
+                except Exception:
+                    resp_json = response.text
+                log.error(f'Decode: type="remote" model={model_type} code={response.status_code} shape={latent.shape} url="{url}" args={params} headers={response.headers} response={resp_json}')
             else:
                 content += len(response.content)
                 if shared.opts.remote_vae_type == 'raw' or 'video' in model_type:
-                    shape = json.loads(response.headers["shape"])
-                    dtype = response.headers["dtype"]
-                    tensor = torch.frombuffer(bytearray(response.content), dtype=dtypes[dtype]).reshape(shape)
+                    try:
+                        shape = json.loads(response.headers.get("shape", "[]"))
+                        dtype = response.headers.get("dtype", "float32")
+                        if dtype in dtypes:
+                            tensor = torch.frombuffer(bytearray(response.content), dtype=dtypes[dtype]).reshape(shape)
+                        else:
+                            log.warning(f'Decode: unknown dtype {dtype}')
+                            continue
+                    except (json.JSONDecodeError, KeyError, ValueError) as e:
+                        log.warning(f'Decode: shape/dtype parsing error {e}')
+                        continue
                     tensors.append(tensor)
                 elif shared.opts.remote_vae_type == 'jpg' or shared.opts.remote_vae_type == 'png':
                     image = Image.open(io.BytesIO(response.content)).convert("RGB")


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all are verifiable by inspection against current dev and the final diffs passed an independent adversarial review. The account owner chose to submit based on Claude's analysis.*

- `model_te.py`: condition checked `quantization_config` (different scope) instead of the just-assigned `quant_config`
- `model_quant.py` (both duplicate sites): chained `getattr` raised AttributeError when model structure does not match `quant_last_model_name`; now guarded
- `vae/sd_vae_remote.py`: (a) `latent_copy` was created then the original `latents` used, discarding the clone; (b) `response.json()` unguarded on non-JSON error bodies (502/504 HTML); (c) hard `response.headers["shape"]/["dtype"]` indexing raises KeyError on malformed response
- `lora/lora_load.py`: suffix-strip loop could empty `parts` then index `parts[-1]` (IndexError)
- `memstats.py`: ZeroDivisionError when `memory_percent()` returns 0.0
- `merging/modules_sdxl.py`: dtype-string split IndexError when no dot present

