### PR TITLE
Fix dead ControlNet-union path, double video-VAE normalization, and four more logic bugs

### DIFF
--- a/modules/control/processor.py
+++ b/modules/control/processor.py
@@ -240,7 +240,7 @@ def preprocess_image(
             if 'strength' in possible:
                 p.task_args['strength'] = p.denoising_strength
             p.init_images = [init_image] * len(active_model)
-        if hasattr(shared.sd_model, 'controlnet') and hasattr(p.task_args, 'control_image') and len(p.task_args['control_image']) > 1 and (shared.sd_model.__class__.__name__ == 'StableDiffusionXLControlNetUnionPipeline'): # special case for controlnet-union
+        if hasattr(shared.sd_model, 'controlnet') and 'control_image' in p.task_args and len(p.task_args['control_image']) > 1 and (shared.sd_model.__class__.__name__ == 'StableDiffusionXLControlNetUnionPipeline'): # special case for controlnet-union
             p.task_args['control_image'] = [[x] for x in p.task_args['control_image']]
             p.task_args['control_mode'] = [[x] for x in p.task_args['control_mode']]
 

--- a/modules/face/instantid.py
+++ b/modules/face/instantid.py
@@ -35,7 +35,7 @@ def instant_id(p: processing.StableDiffusionProcessing, app, source_images, stre
         face = sorted(faces, key=lambda x:(x['bbox'][2]-x['bbox'][0])*x['bbox'][3]-x['bbox'][1])[-1]  # only use the maximum face
         face_embeds.append(torch.from_numpy(face['embedding']))
         face_images.append(draw_kps(source_image, face['kps']))
-        p.extra_generation_params[f"InstantID {i+1}"] = f'{faces[0].det_score:.2f} {"female" if faces[0].gender==0 else "male"} {faces[0].age}y'
+        p.extra_generation_params[f"InstantID {i+1}"] = f'{face.det_score:.2f} {"female" if face.gender==0 else "male"} {face.age}y'
         log.debug(f'InstantID face: score={face.det_score:.2f} gender={"female" if face.gender==0 else "male"} age={face.age} bbox={face.bbox}')
 
     log.debug(f'InstantID loading: model={REPO_ID}')

--- a/modules/postprocess/seedvr_model.py
+++ b/modules/postprocess/seedvr_model.py
@@ -27,6 +27,7 @@ class UpscalerSeedVR(Upscaler):
         ]
         self.model = None
         self.model_loaded = None
+        self.device = devices.device
 
     def load_model(self, path: str):
         model_name = MODELS_MAP.get(path, None)

--- a/modules/processing_class.py
+++ b/modules/processing_class.py
@@ -633,7 +633,7 @@ class StableDiffusionProcessing:
         self.negative_embeds = []
         self.negative_pooleds = []
         self.prompt_attention_masks = []
-        self.negative_prompt_attention_mask = []
+        self.negative_prompt_attention_masks = []
         self.xyz = xyz
         self.abort = False
 

--- a/modules/video_models/video_vae.py
+++ b/modules/video_models/video_vae.py
@@ -50,5 +50,4 @@ def vae_decode_tiny(latents):
     vae = vae.to(device=devices.device, dtype=devices.dtype)
     latents = latents.transpose(1, 2).to(device=devices.device, dtype=devices.dtype)
     images = vae.decode_video(latents, parallel=False).transpose(1, 2).mul_(2).sub_(1)
-    images = images.transpose(1, 2).mul_(2).sub_(1)
     return (images, None)

--- a/pipelines/model_hyimage.py
+++ b/pipelines/model_hyimage.py
@@ -107,9 +107,9 @@ class HunyuanImage3Wrapper(torch.nn.Module):
 
         if height is None and width is None:
             image_size = "auto"
-        if height is None:
+        elif height is None:
             image_size = (width, width)
-        if width is None:
+        elif width is None:
             image_size = (height, height)
         else:
             image_size = (height, width)


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all are verifiable by inspection against current dev and the final diffs passed an independent adversarial review. The account owner chose to submit based on Claude's analysis.*

- `control/processor.py`: `hasattr(p.task_args, 'control_image')` on a dict is always False, so the ControlNet-union special-case path was dead; fixed to `'control_image' in p.task_args`
- `video_models/video_vae.py`: the `.transpose(1, 2).mul_(2).sub_(1)` chain was applied twice in sequence (double transpose + double normalization pushing values to [-3, 1]); removed the duplicate
- `postprocess/seedvr_model.py`: `self.device` used in vae_encode/vae_decode/model_step but never set (AttributeError); now initialized from `devices.device`
- `pipelines/model_hyimage.py`: bare `if/if/else` chain meant the both-None case set `"auto"` then overwrote it with `(None, None)`; restructured to `if/elif/elif/else`
- `processing_class.py`: `negative_prompt_attention_mask = []` (singular) in the globals block while consumers read the plural `negative_prompt_attention_masks`; fixed the name
- `face/instantid.py`: generation metadata logged `faces[0]` stats while the largest face (`face`) is what is actually used

