### PR TITLE
fix(lora-extract): stop overwriting the module selection list; fix dead no-LoRA guard

### DIFF
--- a/modules/lora/lora_extract.py
+++ b/modules/lora/lora_extract.py
@@ -122,7 +122,7 @@ def make_lora(fn, maxrank, auto_rank, rank_ratio, modules, overwrite):
         log.warning(msg)
         yield msg
         return
-    if loaded_lora() == "":
+    if not loaded_lora():
         msg = "LoRA extract: no LoRA detected"
         log.warning(msg)
         yield msg
@@ -141,8 +141,7 @@ def make_lora(fn, maxrank, auto_rank, rank_ratio, modules, overwrite):
     with rp.Progress(rp.TextColumn('[cyan]LoRA extract'), rp.BarColumn(), rp.TaskProgressColumn(), rp.TimeRemainingColumn(), rp.TimeElapsedColumn(), rp.TextColumn('[cyan]{task.description}'), console=console) as progress:
 
         if 'te' in modules and getattr(shared.sd_model, 'text_encoder', None) is not None:
-            modules = shared.sd_model.text_encoder.named_modules()
-            task = progress.add_task(description="te1 decompose", total=len(list(modules)))
+            task = progress.add_task(description="te1 decompose", total=len(list(shared.sd_model.text_encoder.named_modules())))
             for name, module in shared.sd_model.text_encoder.named_modules():
                 progress.update(task, advance=1)
                 weights_backup = getattr(module, "network_weights_backup", None)
@@ -157,8 +156,7 @@ def make_lora(fn, maxrank, auto_rank, rank_ratio, modules, overwrite):
         t1 = time.time()
 
         if 'te' in modules and getattr(shared.sd_model, 'text_encoder_2', None) is not None:
-            modules = shared.sd_model.text_encoder_2.named_modules()
-            task = progress.add_task(description="te2 decompose", total=len(list(modules)))
+            task = progress.add_task(description="te2 decompose", total=len(list(shared.sd_model.text_encoder_2.named_modules())))
             for name, module in shared.sd_model.text_encoder_2.named_modules():
                 progress.update(task, advance=1)
                 weights_backup = getattr(module, "network_weights_backup", None)
@@ -172,8 +170,7 @@ def make_lora(fn, maxrank, auto_rank, rank_ratio, modules, overwrite):
         t2 = time.time()
 
         if 'unet' in modules and getattr(shared.sd_model, 'unet', None) is not None:
-            modules = shared.sd_model.unet.named_modules()
-            task = progress.add_task(description="unet decompose", total=len(list(modules)))
+            task = progress.add_task(description="unet decompose", total=len(list(shared.sd_model.unet.named_modules())))
             for name, module in shared.sd_model.unet.named_modules():
                 progress.update(task, advance=1)
                 weights_backup = getattr(module, "network_weights_backup", None)


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; both are verifiable by inspection against current dev and the final diffs passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
In `make_lora()`, the `modules` selection argument (e.g. `['te','unet']`) is reassigned to a `named_modules()` generator to compute a progress-bar total, then later membership-tested (`'te' in modules`, `'unet' in modules`). Because `modules` is now an **exhausted generator**, those tests evaluate False → **text_encoder_2 and UNet extraction are silently skipped** (on SDXL with `te` selected, only text-encoder-1 is extracted). Separately, `if loaded_lora() == "":` is always False (the function returns a *list* when a model is loaded), so the "no LoRA detected" guard never fires.

### Fix
Compute the progress total inline (`len(list(...named_modules()))`) without rebinding `modules`; change the guard to `if not loaded_lora():`. The default (unet-only) path was already correct; this restores the `te` path.
