### PR TITLE
fix(api): IP-adapter mask accumulation, null params, colon-in-password, raw allowed path

### DIFF
--- a/modules/api/api.py
+++ b/modules/api/api.py
@@ -17,12 +17,12 @@ class Api:
         self.credentials = {}
         if shared.cmd_opts.auth:
             for auth in shared.cmd_opts.auth.split(","):
-                user, password = auth.split(":")
+                user, password = auth.split(":", 1)
                 self.credentials[user.replace('"', '').strip()] = password.replace('"', '').strip()
         if shared.cmd_opts.auth_file:
             with open(shared.cmd_opts.auth_file, encoding="utf8") as file:
                 for line in file.readlines():
-                    user, password = line.split(":")
+                    user, password = line.split(":", 1)
                     self.credentials[user.replace('"', '').strip()] = password.replace('"', '').strip()
         self.router = APIRouter()
         if shared.cmd_opts.docs:

--- a/modules/api/gallery.py
+++ b/modules/api/gallery.py
@@ -3,7 +3,6 @@ import os
 import time
 import base64
 from urllib.parse import quote, unquote
-from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.websockets import WebSocket, WebSocketState
 from pydantic import BaseModel, Field # pylint: disable=no-name-in-module
@@ -173,7 +172,7 @@ def register_api(api): # register api
                 unique_folders.append(f)
                 if shared.demo is not None and path not in shared.demo.allowed_paths:
                     debug(f'Browser folders allow: {path}')
-                    shared.demo.allowed_paths.append(quote(path))
+                    shared.demo.allowed_paths.append(path)
         debug(f'Browser folders: {unique_folders}')
         return JSONResponse(content=unique_folders)
 

--- a/modules/api/generate.py
+++ b/modules/api/generate.py
@@ -70,6 +70,7 @@ class APIGenerate:
             p.ip_adapter_starts = []
             p.ip_adapter_ends = []
             p.ip_adapter_images = []
+            p.ip_adapter_masks = []
             for ipadapter in request.ip_adapter:
                 if not ipadapter.images or len(ipadapter.images) == 0:
                     continue
@@ -79,7 +80,6 @@ class APIGenerate:
                 p.ip_adapter_starts.append(ipadapter.start)
                 p.ip_adapter_ends.append(ipadapter.end)
                 p.ip_adapter_images.append([helpers.decode_base64_to_image(x) for x in ipadapter.images])
-                p.ip_adapter_masks = []
                 if ipadapter.masks:
                     p.ip_adapter_masks.append([helpers.decode_base64_to_image(x) for x in ipadapter.masks])
             del request.ip_adapter

--- a/modules/api/process.py
+++ b/modules/api/process.py
@@ -76,7 +76,7 @@ class APIProcess:
         if processor is None or processor.processor_id != req.model:
             with self.queue_lock:
                 processor = processors.Processor(req.model)
-        for k, v in req.params.items():
+        for k, v in (req.params or {}).items():
             if k not in processors.config[processor.processor_id]['params']:
                 return JSONResponse(status_code=400, content={"error": f"Processor invalid parameter: id={req.model} {k}={v}"})
         jobid = shared.state.begin('API-PRE', api=True)
@@ -102,7 +102,7 @@ class APIProcess:
             return JSONResponse(status_code=400, content={"error": f"Mask type not found: id={req.type}"})
         image = decode_base64_to_image(req.image)
         mask = decode_base64_to_image(req.mask) if req.mask else None
-        for k, v in req.params.items():
+        for k, v in (req.params or {}).items():
             if not hasattr(masking.opts, k):
                 return JSONResponse(status_code=400, content={"error": f"Mask invalid parameter: {k}={v}"})
             else:


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all are verifiable by inspection against current dev and the final diffs passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
Four independent input-handling defects under `modules/api/`:
- **generate.py** — `p.ip_adapter_masks = []` is reset *inside* the per-IP-adapter loop while every sibling list inits once outside, so a multi-IP-adapter request keeps only the last adapter's masks.
- **process.py** (two sites) — `for k, v in req.params.items()` where `params: dict | None`; a request body with `params: null` raises `AttributeError` (unhandled 500).
- **api.py** (two sites) — `auth.split(":")` raises `ValueError` at startup when an `--auth`/auth-file password contains a colon.
- **gallery.py** — appends `quote(path)` (percent-encoded) to `allowed_paths`, while the dedup check and the gradio/endpoints path guards compare the *raw* path → unbounded duplicate growth and an ineffective whitelist (encoded entries never match a real path).

### Fix
Hoist the mask init beside its siblings; `(req.params or {}).items()`; `split(":", 1)`; append the raw `path` (and drop a now-unused `FastAPI` import).
