### PR TITLE
fix(runtime): capture bias dtype cast, coerce env seq-len to int, init pipeline before use

### DIFF
--- a/modules/sd_detect.py
+++ b/modules/sd_detect.py
@@ -187,6 +187,7 @@ def guess_by_diffusers(fn, current_guess):
         cls = index.get('_class_name', None)
         if isinstance(cls, list):
             cls = cls[-1]
+        pipeline = None
         if cls is not None:
             pipeline = getattr(diffusers, cls, None)
             if pipeline is None:

--- a/modules/sd_hijack_accelerate.py
+++ b/modules/sd_hijack_accelerate.py
@@ -84,7 +84,7 @@ def torch_conv_forward(self, input, weight, bias): # pylint: disable=redefined-b
     if self.padding_mode != 'zeros':
         return F.conv2d(F.pad(input, self._reversed_padding_repeated_twice, mode=self.padding_mode), weight, bias, self.stride, _pair(0), self.dilation, self.groups) # pylint: disable=protected-access
     if weight.dtype != bias.dtype:
-        bias.to(weight.dtype)
+        bias = bias.to(weight.dtype)
     return F.conv2d(input, weight, bias, self.stride, self.padding, self.dilation, self.groups)
 
 def hijack_torch_conv():

--- a/modules/sd_hijack_te.py
+++ b/modules/sd_hijack_te.py
@@ -8,7 +8,7 @@ def hijack_encode_prompt(*args, **kwargs):
     jobid = shared.state.begin('TE Encode')
     t0 = time.time()
     if 'max_sequence_length' in kwargs and kwargs['max_sequence_length'] is not None:
-        kwargs['max_sequence_length'] = max(kwargs['max_sequence_length'], os.environ.get('MAX_SEQUENCE_LENGTH', 256))
+        kwargs['max_sequence_length'] = max(kwargs['max_sequence_length'], int(os.environ.get('MAX_SEQUENCE_LENGTH', 256)))
     res = None
     try:
         args_copy = list(args)


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; all are verifiable by inspection against current dev and the final diffs passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
Three independent runtime guards:
- **sd_hijack_accelerate.py** — `bias.to(weight.dtype)` discards its result (`Tensor.to` is not in-place), so the dtype-mismatch guard is a no-op and the conv still receives the mismatched-dtype bias.
- **sd_hijack_te.py** — `max(kwargs['max_sequence_length'], os.environ.get('MAX_SEQUENCE_LENGTH', 256))`: when the env var is set it is a `str` → `max(int, str)` raises `TypeError` (before the `try`, uncaught) → prompt encoding crashes whenever the override is set.
- **sd_detect.py** — `pipeline` is referenced in `if callable(pipeline)` but assigned only inside `if cls is not None`, so a diffusers folder whose `model_index.json` lacks `_class_name` raises `UnboundLocalError`.

### Fix
`bias = bias.to(...)`; `int(os.environ.get('MAX_SEQUENCE_LENGTH', 256))`; initialize `pipeline = None` before the conditional.
