### PR TITLE
fix(control-units): list zimage controlnets under 'all'; fix LLLite output-block fall-through

### DIFF
--- a/modules/control/units/controlnet.py
+++ b/modules/control/units/controlnet.py
@@ -179,7 +179,7 @@ def api_list_models(model_type: str | None = None):
         model_list += list(predefined_qwen)
     if model_type == 'hunyuandit' or model_type == 'all':
         model_list += list(predefined_hunyuandit)
-    if model_type == 'zimage':
+    if model_type == 'zimage' or model_type == 'all':
         model_list += list(predefined_zimage)
     model_list += sorted(find_models())
     return model_list

--- a/modules/control/units/lite_model.py
+++ b/modules/control/units/lite_model.py
@@ -171,7 +171,7 @@ class ControlNetLLLite(torch.nn.Module): # pylint: disable=abstract-method
                 mapped_block, mapped_number = map_down_lllite_to_unet[int(block)]
                 b = model.down_blocks[mapped_block].attentions[int(mapped_number)].transformer_blocks[int(block_number)]
             elif root == 'output':
-                pass # not implemented
+                continue # not implemented
             else:
                 b = model.mid_block.attentions[0].transformer_blocks[int(block_number)]
             b = getattr(b, attn_name, None)


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bugs and wrote the fixes; both are verifiable by inspection against current dev and the final diffs passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
- **controlnet.py** — `api_list_models` omits `or model_type == 'all'` for `zimage`, so ZImage ControlNets never appear in the `'all'` listing (every other family includes it).
- **lite_model.py** — in the key-mapping loop, the `root == 'output'` branch ("not implemented") uses `pass`, falling through to `b = getattr(b, attn_name, None)` with `b` unbound or stale from a prior iteration → `UnboundLocalError`/wrong-block patch for any LLLite checkpoint carrying output-block keys.

### Fix
Add `or model_type == 'all'` for zimage; change the output-block `pass` to `continue`.
