### PR TITLE
fix(hypertile): correct width/height mapping in hires set_resolution

### DIFF
--- a/modules/sd_hijack_hypertile.py
+++ b/modules/sd_hijack_hypertile.py
@@ -259,8 +259,8 @@ def set_resolution(p, hr=False):
     if hr:
         x = getattr(p, 'hr_upscale_to_x', 0)
         y = getattr(p, 'hr_upscale_to_y', 0)
-        width = y if y > 0 else p.width
-        height = x if x > 0 else p.height
+        width = x if x > 0 else p.width
+        height = y if y > 0 else p.height
     else:
         width = p.width
         height = p.height


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bug and wrote the fix; it is verifiable by inspection against current dev and the final diff passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
In `modules/sd_hijack_hypertile.py`, `set_resolution(p, hr=True)` assigns the HyperTile tile-grid dimensions from transposed axes — `width` from `hr_upscale_to_y`, `height` from `hr_upscale_to_x`. But `hr_upscale_to_x` is the width and `hr_upscale_to_y` the height (consistent with `processing_class.py`, `processing_diffusers.py`, `processing_info.py`, etc.). On a non-square hires pass with HyperTile enabled, this transposes the tile geometry.

### Fix
Swap so `width = x`, `height = y` — matching the (already-correct) non-hr branch and the rest of the codebase. 2-line change.
