### PR TITLE
fix(video): clear p.styles after prepare_prompt to avoid double style application

### DIFF
--- a/modules/video_models/video_prompt.py
+++ b/modules/video_models/video_prompt.py
@@ -5,6 +5,7 @@ def prepare_prompt(p, init_image, prompt:str, vlm_enhance:bool, vlm_model:str, v
     p.prompt = shared.prompt_styles.apply_styles_to_prompt(p.prompt, p.styles)
     p.negative_prompt = shared.prompt_styles.apply_negative_styles_to_prompt(p.negative_prompt, p.styles)
     shared.prompt_styles.apply_styles_to_extra(p)
+    p.styles = [] # styles are now folded into the prompt; clear so video_utils.set_prompt() does not apply them a second time
     p.prompts, p.network_data = extra_networks.parse_prompts([p.prompt])
     extra_networks.activate(p)
     prompt = p.prompts[0]


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bug and wrote the fix; it is verifiable by inspection against current dev and the final diff passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
In `modules/video_models/video_prompt.py`, `prepare_prompt` folds styles into the prompt but does not clear `p.styles`; `video_run` then calls `video_utils.set_prompt`, which applies the same styles **again** → style text duplicated in the final video prompt.

### Fix
Clear `p.styles` after `prepare_prompt` folds them in, so the later `set_prompt` re-apply is a no-op. No saved-metadata regression: `set_prompt` already clears `p.styles` before the video is saved.
