### PR TITLE
fix(pixelart): squeeze channel dim before writing back into the 3D slice

### DIFF
--- a/modules/postprocess/pixelart.py
+++ b/modules/postprocess/pixelart.py
@@ -37,9 +37,9 @@ def img_to_pixelart(image: PipelineImageInput, sharpen: float = 0, block_size: i
         cr = ycbcr[:,2,:,:].unsqueeze(1)
 
     new_image = torch.zeros_like(new_image)
-    new_image[:,0,:,:] = y
-    new_image[:,block_size_sq,:,:] = cb
-    new_image[:,block_size_sq*2,:,:] = cr
+    new_image[:,0,:,:] = y.squeeze(1)
+    new_image[:,block_size_sq,:,:] = cb.squeeze(1)
+    new_image[:,block_size_sq*2,:,:] = cr.squeeze(1)
     new_image = processor.decode(new_image, return_type=return_type)
     return new_image
 


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bug and wrote the fix; it is verifiable by inspection against current dev and the final diff passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
In `modules/postprocess/pixelart.py` `img_to_pixelart()`, `y`/`cb`/`cr` are `.unsqueeze(1)`'d to `[B,1,H,W]` (needed for the sharpen `torch.cat`) and then assigned into `new_image[:, c, :, :]`, which is a `[B,H,W]` slice. Assigning a 4-D value into a 3-D slice raises `RuntimeError` (PyTorch index-assignment expands but never reduces rank) — on **every** call to the pixel-art postprocessor.

### Fix
`.squeeze(1)` on write-back so the value is `[B,H,W]`, matching the slice; values are identical to intent.

### Testing
Reproduced the original `RuntimeError` and confirmed the fix produces the correct output.
