### PR TITLE
fix(lora): guard self.shape for modules without a weight attribute

### DIFF
--- a/modules/lora/network.py
+++ b/modules/lora/network.py
@@ -166,6 +166,7 @@ class NetworkModule:
         self.network_key = weights.network_key
         self.sd_key = weights.sd_key
         self.sd_module = weights.sd_module
+        self.shape = None
         if hasattr(self.sd_module, 'weight'):
             if hasattr(self.sd_module, "sdnq_dequantizer"):
                 self.shape = self.sd_module.sdnq_dequantizer.original_shape
@@ -176,7 +177,7 @@ class NetworkModule:
         self.alpha = weights.w["alpha"].item() if "alpha" in weights.w else None
         self.scale = weights.w["scale"].item() if "scale" in weights.w else None
         self.dora_scale = weights.w.get("dora_scale", None)
-        self.dora_norm_dims = len(self.shape) - 1
+        self.dora_norm_dims = (len(self.shape) - 1) if self.shape is not None else None
 
     def multiplier(self):
         unet_multiplier = 3 * [self.network.unet_multiplier] if not isinstance(self.network.unet_multiplier, list) else self.network.unet_multiplier


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found the bug and wrote the fix; it is verifiable by inspection against current dev and the final diff passed an independent adversarial review by a separate Claude agent. The account owner chose to submit based on Claude's analysis.*

### Issue
In `NetworkModule.__init__` (`modules/lora/network.py`), `self.shape` is set only inside `if hasattr(self.sd_module, 'weight')`, but `self.dora_norm_dims = len(self.shape) - 1` runs unconditionally → `AttributeError` when a LoRA targets a weightless module (an activation/normalization/container layer matched by a malformed or cross-architecture adapter). The construction is not exception-wrapped, so it aborts the entire LoRA load.

### Fix
Default `self.shape = None` and compute `dora_norm_dims` only when shape is present. This hardens the loader against weightless target modules; the common weighted-module path is byte-for-byte unchanged.
