### PR TITLE
fix(control): SegmentAnything 1.0 fails to load after processor rename

### DIFF
--- a/modules/control/processors.py
+++ b/modules/control/processors.py
@@ -282,10 +282,10 @@ class Processor:
             elif processor_id in ('DWPose (ONNX)', 'RTMW', 'RTMO'):
                 model_type = {'DWPose (ONNX)': 'DWPose', 'RTMW': 'RTMW-l', 'RTMO': 'RTMO-l'}[processor_id]
                 self.model = cls.from_pretrained(model_type, **self.load_config)
-            elif 'SegmentAnything' in processor_id:
-                if 'Base' == config['SegmentAnything']['model']:
+            elif processor_id == 'SegmentAnything 1.0':
+                if 'Base' == config[processor_id]['model']:
                     self.model = cls.from_pretrained(model_path = 'segments-arnaud/sam_vit_b', filename='sam_vit_b_01ec64.pth', model_type='vit_b', **self.load_config)
-                elif 'Large' == config['SegmentAnything']['model']:
+                elif 'Large' == config[processor_id]['model']:
                     self.model = cls.from_pretrained(model_path = 'segments-arnaud/sam_vit_l', filename='sam_vit_l_0b3195.pth', model_type='vit_l', **self.load_config)
                 else:
                     log.error(f'Control Processor load failed: id="{processor_id}" error=unknown model type')


### PR DESCRIPTION
*Disclosure: authored by Claude (Anthropic's coding agent), which found and fixed this bug and reproduced it against current dev (the load-path lookup raises KeyError on dev and resolves with the fix).*

## Summary
The control processor `SegmentAnything` was renamed to `SegmentAnything 1.0` / `SegmentAnything 2.1` (config keys in `modules/control/processors.py`), but `Processor.load()` still matched the old name and indexed the now-nonexistent `config['SegmentAnything']` key:
```python
elif 'SegmentAnything' in processor_id:
    if 'Base' == config['SegmentAnything']['model']:   # KeyError: 'SegmentAnything'
```
Selecting **SegmentAnything 1.0** raises `KeyError` (caught by `load()`'s handler and reported as a load failure), so the processor never loads.

## Fix
Match the exact processor id and index it directly:
```python
elif processor_id == 'SegmentAnything 1.0':
    if 'Base' == config[processor_id]['model']:
```
Switching from the substring match to an exact match also lets `SegmentAnything 2.1` fall through to the generic `load_config` branch (`Sam2Detector.from_pretrained(pretrained_model_or_path='facebook/sam2.1-hiera-large')`, its correct loader); 2.1 hit the same `KeyError` under the old branch, so it's fixed too.

## Testing
Reproduced against the running module on current `dev`: `config['SegmentAnything']['model']` raises `KeyError: 'SegmentAnything'`; `config['SegmentAnything 1.0']['model']` resolves to `'Base'`. (The downstream model download wasn't exercised; the defect and its correction are in the config lookup.)
