### PR TITLE
fix(control): update stale processor names in update_settings and XYZ list

### DIFF
--- a/modules/control/processor.py
+++ b/modules/control/processor.py
@@ -17,7 +17,6 @@ processors = [
     'None',
     # pose
     'OpenPose',
-    'DWPose',
     'RTMW',
     'RTMO',
     'ViTPose',

--- a/modules/control/processors.py
+++ b/modules/control/processors.py
@@ -52,7 +52,7 @@ config = {
     'Shuffle': {'class': None, 'group': 'Other', 'checkpoint': False, 'params': {}},
     # legacy models
     'MediaPipe Face (Legacy)': {'class': None, 'group': 'Pose', 'checkpoint': False, 'params': {'max_faces': 1, 'min_confidence': 0.5}},
-    'DWPose (Legacy)': {'class': None, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3}},
+    'DWPose (Legacy)': {'class': None, 'group': 'Pose', 'checkpoint': False, 'model': 'Tiny', 'params': {'min_confidence': 0.3}},
     'TEED (Legacy)': {'class': None, 'group': 'Edge', 'checkpoint': True, 'load_config': {'pretrained_model_or_path': 'fal/teed'}, 'params': {}},
     'Anyline (Legacy)': {'class': None, 'group': 'Edge', 'checkpoint': True, 'load_config': {'pretrained_model_or_path': 'TheMistoAI/MistoLine'}, 'params': {}},
     'Normal Bae (Legacy)': {'class': None, 'group': 'Normal', 'checkpoint': True, 'params': {}},
@@ -98,7 +98,7 @@ def delay_load_config():
         # pose models
         'OpenPose': {'class': OpenposeDetector, 'group': 'Pose', 'checkpoint': True, 'params': {'include_body': True, 'include_hand': False, 'include_face': False}},
         'MediaPipe Face (Legacy)': {'class': MediapipeFaceDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'max_faces': 1, 'min_confidence': 0.5}},
-        'DWPose (Legacy)': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3}},
+        'DWPose (Legacy)': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'model': 'Tiny', 'params': {'min_confidence': 0.3}},
         'RTMW': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3, 'draw_body_pose': True, 'draw_hand_pose': True, 'draw_face_pose': True}},
         'RTMO': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3}},
         'ViTPose': {'class': ViTPoseDetector, 'group': 'Pose', 'checkpoint': True, 'load_config': {'pretrained_model_or_path': 'usyd-community/vitpose-plus-base'}, 'params': {'min_confidence': 0.3}},
@@ -179,13 +179,13 @@ def update_settings(*settings):
     update(['Leres Depth', 'params', 'boost'], settings[11])
     update(['Leres Depth', 'params', 'thr_a'], settings[12])
     update(['Leres Depth', 'params', 'thr_b'], settings[13])
-    update(['MediaPipe Face', 'params', 'max_faces'], settings[14])
-    update(['MediaPipe Face', 'params', 'min_confidence'], settings[15])
+    update(['MediaPipe Face (Legacy)', 'params', 'max_faces'], settings[14])
+    update(['MediaPipe Face (Legacy)', 'params', 'min_confidence'], settings[15])
     update(['Canny', 'params', 'low_threshold'], settings[16])
     update(['Canny', 'params', 'high_threshold'], settings[17])
-    update(['DWPose', 'model'], settings[18])
-    update(['DWPose', 'params', 'min_confidence'], settings[19])
-    update(['SegmentAnything', 'model'], settings[20])
+    update(['DWPose (Legacy)', 'model'], settings[18])
+    update(['DWPose (Legacy)', 'params', 'min_confidence'], settings[19])
+    update(['SegmentAnything 1.0', 'model'], settings[20])
     update(['Edge', 'params', 'pf'], settings[21])
     update(['Edge', 'params', 'mode'], settings[22])
     update(['Zoe Depth', 'params', 'gamma_corrected'], settings[23])
@@ -264,23 +264,8 @@ class Processor:
             # log.debug(f'Control Processor loading: id="{processor_id}" class={cls.__name__}')
             debug(f'Control Processor config={self.load_config}')
             jobid = state.begin('Load processor')
-            if processor_id == 'DWPose':
-                det_ckpt = 'https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_l_8x8_300e_coco/yolox_l_8x8_300e_coco_20211126_140236-d3bd2b23.pth'
-                if 'Tiny' == config['DWPose']['model']:
-                    pose_config = 'config/rtmpose-t_8xb64-270e_coco-ubody-wholebody-256x192.py'
-                    pose_ckpt = 'https://huggingface.co/yzd-v/DWPose/resolve/main/dw-tt_ucoco.pth'
-                elif 'Medium' == config['DWPose']['model']:
-                    pose_config = 'config/rtmpose-m_8xb64-270e_coco-ubody-wholebody-256x192.py'
-                    pose_ckpt = 'https://huggingface.co/yzd-v/DWPose/resolve/main/dw-mm_ucoco.pth'
-                elif 'Large' == config['DWPose']['model']:
-                    pose_config = 'config/rtmpose-l_8xb32-270e_coco-ubody-wholebody-384x288.py'
-                    pose_ckpt = 'https://huggingface.co/yzd-v/DWPose/resolve/main/dw-ll_ucoco_384.pth'
-                else:
-                    log.error(f'Control Processor load failed: id="{processor_id}" error=unknown model type')
-                    return f'Processor failed to load: {processor_id}'
-                self.model = cls(det_ckpt=det_ckpt, pose_config=pose_config, pose_ckpt=pose_ckpt, device="cpu")
-            elif processor_id in ('DWPose (ONNX)', 'RTMW', 'RTMO'):
-                model_type = {'DWPose (ONNX)': 'DWPose', 'RTMW': 'RTMW-l', 'RTMO': 'RTMO-l'}[processor_id]
+            if processor_id in ('DWPose (Legacy)', 'RTMW', 'RTMO'):
+                model_type = {'DWPose (Legacy)': 'DWPose', 'RTMW': 'RTMW-l', 'RTMO': 'RTMO-l'}[processor_id]
                 self.model = cls.from_pretrained(model_type, **self.load_config)
             elif processor_id == 'SegmentAnything 1.0':
                 if 'Base' == config[processor_id]['model']:


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which found these bugs and reproduced Bug 1 on a live process against current dev; Bugs 2 and 3 confirmed by inspection.*

## Summary

The `8d4ebcd5e "processors multiple fixes"` rename (`DWPose (ONNX)` → `DWPose (Legacy)`, `MediaPipe Face` → `MediaPipe Face (Legacy)`, `SegmentAnything` → `SegmentAnything 1.0` / `2.1`) left three stale names in `update_settings()`, a broken load path for `DWPose (Legacy)`, and a stale entry in the XYZ processor list. Fixes all three, closes #4953.

## Bug 1 (main): `update_settings()` KeyError silently drops 9 of 16 settings panels

`update_settings()` indexed three renamed keys directly — `'MediaPipe Face'`, `'DWPose'`, `'SegmentAnything'` — none of which exist in `config` after the rename. The crash at the first stale key (`'MediaPipe Face'`, line 182) means every `update()` call at position ≥14 never runs, so Canny, Edge, Zoe, Marigold, Depth Anything, and Depth Pro settings also stop persisting despite their own keys being valid.

Repro against current `dev` (before this fix):
```python
import modules.control.processors as p
p.update_settings(*([0.0] * 30))
# KeyError: 'MediaPipe Face'
```

Fix: update the three stale names to their post-rename equivalents. `DWPose (Legacy)` was also missing the `model` key its `update_settings` call expects, so that key is added to both config entries.

## Bug 2: `DWPose (Legacy)` load path broken after rename

The load dispatch still matched on `'DWPose (ONNX)'` (the pre-rename name). After the rename to `'DWPose (Legacy)'`, selecting that processor falls through to `cls()` with no arguments — `RtmlibPoseDetector()` requires positional args, so every load attempt raises `TypeError`. The dead mmpose `'DWPose'` load branch (lines 267–281), which reads the now-absent `config['DWPose']`, is also removed.

Fix: replace the stale `'DWPose (ONNX)'` dispatch entry with `'DWPose (Legacy)'` (same rtmlib `'DWPose'` model type); remove the dead mmpose `'DWPose'` branch.

## Bug 3 (minor): XYZ `[Control] Processor` axis offered unloadable `DWPose`

`processor.processors` (consumed by `xyz_grid_classes.py` line 275 as the XYZ axis choices) still contained the bare `'DWPose'` entry whose config key was already removed by the rename. Selecting it would fail at the `processor_id not in config` guard. `'DWPose (Legacy)'` is already present in the list; the stale entry is removed.

## Changes

- `modules/control/processors.py`: fix three stale keys in `update_settings()`; add `'model': 'Tiny'` to both `DWPose (Legacy)` config entries; fix load dispatch (`DWPose (Legacy)` → rtmlib `'DWPose'`); remove dead mmpose `'DWPose'` load branch
- `modules/control/processor.py`: remove stale `'DWPose'` from `processors` list
