### PR TITLE
fix(control): remove inert DWPose (Legacy) pose-model selector

### DIFF
--- a/modules/control/processors.py
+++ b/modules/control/processors.py
@@ -52,7 +52,7 @@ config = {
     'Shuffle': {'class': None, 'group': 'Other', 'checkpoint': False, 'params': {}},
     # legacy models
     'MediaPipe Face (Legacy)': {'class': None, 'group': 'Pose', 'checkpoint': False, 'params': {'max_faces': 1, 'min_confidence': 0.5}},
-    'DWPose (Legacy)': {'class': None, 'group': 'Pose', 'checkpoint': False, 'model': 'Tiny', 'params': {'min_confidence': 0.3}},
+    'DWPose (Legacy)': {'class': None, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3}},
     'TEED (Legacy)': {'class': None, 'group': 'Edge', 'checkpoint': True, 'load_config': {'pretrained_model_or_path': 'fal/teed'}, 'params': {}},
     'Anyline (Legacy)': {'class': None, 'group': 'Edge', 'checkpoint': True, 'load_config': {'pretrained_model_or_path': 'TheMistoAI/MistoLine'}, 'params': {}},
     'Normal Bae (Legacy)': {'class': None, 'group': 'Normal', 'checkpoint': True, 'params': {}},
@@ -98,7 +98,7 @@ def delay_load_config():
         # pose models
         'OpenPose': {'class': OpenposeDetector, 'group': 'Pose', 'checkpoint': True, 'params': {'include_body': True, 'include_hand': False, 'include_face': False}},
         'MediaPipe Face (Legacy)': {'class': MediapipeFaceDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'max_faces': 1, 'min_confidence': 0.5}},
-        'DWPose (Legacy)': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'model': 'Tiny', 'params': {'min_confidence': 0.3}},
+        'DWPose (Legacy)': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3}},
         'RTMW': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3, 'draw_body_pose': True, 'draw_hand_pose': True, 'draw_face_pose': True}},
         'RTMO': {'class': RtmlibPoseDetector, 'group': 'Pose', 'checkpoint': False, 'params': {'min_confidence': 0.3}},
         'ViTPose': {'class': ViTPoseDetector, 'group': 'Pose', 'checkpoint': True, 'load_config': {'pretrained_model_or_path': 'usyd-community/vitpose-plus-base'}, 'params': {'min_confidence': 0.3}},
@@ -183,17 +183,16 @@ def update_settings(*settings):
     update(['MediaPipe Face (Legacy)', 'params', 'min_confidence'], settings[15])
     update(['Canny', 'params', 'low_threshold'], settings[16])
     update(['Canny', 'params', 'high_threshold'], settings[17])
-    update(['DWPose (Legacy)', 'model'], settings[18])
-    update(['DWPose (Legacy)', 'params', 'min_confidence'], settings[19])
-    update(['SegmentAnything 1.0', 'model'], settings[20])
-    update(['Edge', 'params', 'pf'], settings[21])
-    update(['Edge', 'params', 'mode'], settings[22])
-    update(['Zoe Depth', 'params', 'gamma_corrected'], settings[23])
-    update(['Marigold Depth', 'params', 'color_map'], settings[24])
-    update(['Marigold Depth', 'params', 'denoising_steps'], settings[25])
-    update(['Marigold Depth', 'params', 'ensemble_size'], settings[26])
-    update(['Depth Anything', 'params', 'color_map'], settings[27])
-    update(['Depth Pro', 'params', 'color_map'], settings[28])
+    update(['DWPose (Legacy)', 'params', 'min_confidence'], settings[18])
+    update(['SegmentAnything 1.0', 'model'], settings[19])
+    update(['Edge', 'params', 'pf'], settings[20])
+    update(['Edge', 'params', 'mode'], settings[21])
+    update(['Zoe Depth', 'params', 'gamma_corrected'], settings[22])
+    update(['Marigold Depth', 'params', 'color_map'], settings[23])
+    update(['Marigold Depth', 'params', 'denoising_steps'], settings[24])
+    update(['Marigold Depth', 'params', 'ensemble_size'], settings[25])
+    update(['Depth Anything', 'params', 'color_map'], settings[26])
+    update(['Depth Pro', 'params', 'color_map'], settings[27])
 
 
 class Processor:

--- a/modules/ui_control_elements.py
+++ b/modules/ui_control_elements.py
@@ -307,7 +307,6 @@ def create_ui_elements(units, result_txt, output_gallery):
                     settings.append(gr.Slider(label="Low threshold", minimum=0, maximum=1000, step=1, value=100))
                     settings.append(gr.Slider(label="High threshold", minimum=0, maximum=1000, step=1, value=200))
                 with gr.Accordion('DWPose', open=True, elem_classes=['processor-settings']):
-                    settings.append(gr.Radio(label="Pose Model", choices=['Tiny', 'Medium', 'Large'], value='Tiny'))
                     settings.append(gr.Slider(label="Pose confidence", minimum=0.0, maximum=1.0, step=0.01, value=0.3))
                 with gr.Accordion('SegmentAnything 1.0', open=True, elem_classes=['processor-settings']):
                     settings.append(gr.Radio(label="Segment Model", choices=['Base', 'Large'], value='Base'))


### PR DESCRIPTION
### What

The DWPose (Legacy) "Pose Model" selector (Tiny / Medium / Large) is a no-op. It writes to `config['DWPose (Legacy)']['model']`, but the rtmlib backend (`RtmlibPoseDetector.from_pretrained`) only takes the mode string and always loads RTMPose `lightweight` - it never reads that key. The only readers of a processor `['model']` key are the SegmentAnything branch in `processors.py`. The selector is a leftover from the mmpose `DWPose` processor that #4956 removed.

### Change

- Remove the radio from the DWPose (Legacy) settings accordion (keeping the functional Pose confidence slider).
- Remove the dead `'model'` key from both the module-level and `delay_load_config` copies of `config['DWPose (Legacy)']`.
- Drop the corresponding `update_settings` line and reindex the remaining `settings[18..27]`. The settings list stays 1:1 with the UI controls (re-derived the append-order -> update_settings map to confirm; this is the same positional map #4956 corrected).

No runtime behavior change: DWPose (Legacy) already always loaded RTMPose lightweight.

### Alternative

If you'd rather keep the capability, the radio could instead be wired to rtmlib's `mode` (e.g. Tiny -> lightweight, Medium -> balanced, Large -> performance). I didn't take that here because it changes which model loads and I'd want to runtime-test it first - happy to do that version instead if you prefer.

---
*Disclosure: found and prepared with Claude Code (Opus). Verified by static code tracing of the merged tree (config/UI positional alignment re-derived; ruff + pylint clean); not runtime-tested, since the change removes a control that already had no runtime effect.*
