### PR TITLE
fix(mask): guard zero-area divide in auto-mask Edge mode

### DIFF
--- a/modules/masking.py
+++ b/modules/masking.py
@@ -340,7 +340,7 @@ def get_mask(input_image: gr.Image, input_mask: gr.Image):
             largest_size = cv2.contourArea(contours[0]) if len(contours) > 0 else 0
             for i, contour in enumerate(contours):
                 area_size = cv2.contourArea(contour)
-                luminance = int(255.0 * area_size / largest_size)
+                luminance = int(255.0 * area_size / largest_size) if largest_size > 0 else 0
                 if luminance < 1:
                     break
                 cv2.drawContours(output_mask, contours, i, (luminance), -1)


### PR DESCRIPTION
### What

In `get_mask()` "Edge" auto-mask mode (`modules/masking.py`), `largest_size` is set to `0` when there are no contours — but the luminance loop is also reached when contours *do* exist whose largest has zero area (thin 1px / degenerate features, where `cv2.contourArea` returns `0`). That path computes `int(255.0 * area_size / largest_size)` and raises `ZeroDivisionError`, crashing auto-masking. The existing `if len(contours) > 0 else 0` guards only the empty-contour case, not the zero-area-largest case.

### Change

`modules/masking.py` — guard the divide:

- `luminance = int(255.0 * area_size / largest_size) if largest_size > 0 else 0`

When `largest_size` is `0`, luminance is `0`, so the loop breaks on the first iteration and returns an empty mask — the sensible "no usable region" result. The normal path (a non-zero largest contour) is unchanged.

### Repro

Run Edge auto-mask on an image whose Otsu-threshold yields only thin/zero-area contours (e.g. a 1px diagonal line on black). Before: `ZeroDivisionError` at the luminance line. After: returns an empty mask, no crash.

---
*Disclosure: found and prepared with Claude Code, and reproduced live against the real `get_mask` — the unpatched line raises `ZeroDivisionError` on a thin-feature image; the patched line returns an empty mask. Confirmed present unchanged on current `dev`/`master`. ruff + pylint clean.*
