### PR TITLE
fix: detect hipBLASLt Tensile library in nested per-arch subfolder

### DIFF
--- a/modules/rocm.py
+++ b/modules/rocm.py
@@ -113,7 +113,8 @@ class Agent:
         else:
             self.arch = MicroArchitecture.GCN
         self.is_apu = (self.gfx_version & 0xFFF0 == 0x1150) or self.gfx_version in (0x801, 0x902, 0x90c, 0x1013, 0x1033, 0x1035, 0x1036, 0x1103,)
-        self.blaslt_supported = False if blaslt_tensile_libpath is None else os.path.exists(os.path.join(blaslt_tensile_libpath, f"TensileLibrary_lazy_{self.name}.dat"))
+        blaslt_filename = f"TensileLibrary_lazy_{self.name}.dat"
+        self.blaslt_supported = blaslt_tensile_libpath is not None and (os.path.exists(os.path.join(blaslt_tensile_libpath, blaslt_filename)) or os.path.exists(os.path.join(blaslt_tensile_libpath, self.name, blaslt_filename)))
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
## Description

On multi-arch ROCm wheels, hipBLASLt ships its Tensile library in a per-arch subfolder instead of flat. The detection in `Agent.__init__` only checks the flat path, so it reports hipBLASLt as unavailable even when the library is present and usable. This makes the check also look in the per-arch subfolder.

## Notes

Old check: `<blaslt_tensile_libpath>/TensileLibrary_lazy_<arch>.dat`
Affected layout: `<blaslt_tensile_libpath>/<arch>/TensileLibrary_lazy_<arch>.dat`

The flat check stays as the first condition and the nested path is only a fallback, so existing layouts are unaffected - it can only newly-detect a file the old logic missed. This fixes detection; it assumes hipBLASLt loads the nested file on these wheels, which held in testing.

## Environment and Testing

- OS: Windows 11
- Torch: `2.12.0+rocm7.14.0a` multi-arch wheel
- GPU: RDNA4 (gfx120X)

Before: startup logs `hipBLASLt unavailable` despite the file being present.
After: warning gone, image generation completes with no rocBLAS/hipBLASLt errors.