### PR TITLE
feat(ui): hover legend for the performance info line below the image

### DIFF
--- a/modules/call_queue.py
+++ b/modules/call_queue.py
@@ -92,6 +92,6 @@ def wrap_gradio_call(func, extra_outputs=None, add_stats=False, name=None):
         summary = timer.process.summary(min_time=0.25, total=False).replace('=', ' ')
         memory = shared.mem_mon.summary()
         if isinstance(res, list) and isinstance(res[-1], str):
-            res[-1] += f"<div class='performance'><p>Time: {elapsed_text} | {summary} {memory}</p></div>"
+            res[-1] += f"<div class='performance' title='{timer.perf_legend}'><p>Time: {elapsed_text} | {summary} {memory}</p></div>"
         return tuple(res)
     return f

--- a/modules/timer.py
+++ b/modules/timer.py
@@ -76,3 +76,19 @@ process = Timer()
 launch = Timer()
 init = Timer()
 load = Timer()
+# hover legend for the .performance timing line on the image-generation tabs (used as its title= tooltip):
+# names each field the image summary() emits and hints what can be tuned
+perf_legend = (
+    'total: total generate time&#10;'
+    'onload: moving modules from RAM to GPU&#10;'
+    'prompt: parse and text-encode&#10;'
+    'pipeline: model denoise (UNet / transformer)&#10;'
+    'preview: TAESD live preview&#10;'
+    'move: moving modules between GPU and RAM&#10;'
+    'decode: VAE decode&#10;'
+    'GPU / RAM: peak VRAM and system memory used&#10;&#10;'
+    'tip: high move / onload means the model is re-offloaded to CPU each run; '
+    'pinning it resident (Model types not to offload / Modules to never offload, '
+    'or a higher Offload low watermark) trades VRAM for speed; leave it offloaded '
+    'if you need the VRAM for hires decode'
+)

--- a/modules/ui_control.py
+++ b/modules/ui_control.py
@@ -45,7 +45,7 @@ def return_stats(t: float | None = None):
     if ram['used'] > 0:
         cpu += f"| RAM {ram['used']} GB"
         cpu += f" {round(100.0 * ram['used'] / ram['total'])}%" if ram['total'] > 0 else ''
-    return f"<div class='performance'><p>{elapsed_text} {summary} {gpu} {cpu}</p></div>"
+    return f"<div class='performance' title='{timer.perf_legend}'><p>{elapsed_text} {summary} {gpu} {cpu}</p></div>"
 
 
 def return_controls(res, t: float | None = None):


### PR DESCRIPTION
*Disclosure: this PR was authored by Claude (Anthropic's coding agent), which implemented the info-line hint and verified the rendered markup by inspection against current dev.*

Follows up on the info-line hint from the #4968 discussion — rather than changing offload behaviour, this makes the existing performance/timing line under each image self-explanatory.

The line already prints e.g.:

`Time: 5.52s | total 8.57 pipeline 3.60 decode 1.80 onload 1.02 prompt 0.77 preview 0.76 move 0.46 | GPU 11238 MB 46% | RAM 15.73 GB 24%`

...but the field names are terse. This adds a hover `title` tooltip (a shared `timer.perf_legend`) on the `.performance` div that spells out each field and hints what to tune:

```
total: total generate time
onload: moving modules from RAM to GPU
prompt: parse and text-encode
pipeline: model denoise (UNet / transformer)
preview: TAESD live preview
move: moving modules between GPU and RAM
decode: VAE decode
GPU / RAM: peak VRAM and system memory used

tip: high move / onload means the model is re-offloaded to CPU each run; pinning it resident (Model types not to offload / Modules to never offload, or a higher Offload low watermark) trades VRAM for speed; leave it offloaded if you need the VRAM for hires decode
```

Display-only: a static string plus one `title` attribute per line, no behaviour change, nothing added to the hot path.

It's applied to the image-generation info lines (txt2img/img2img and control), whose emitted fields the glossary describes. The LTX/framepack video lines emit different timers (`base` / `upsample` / `refine`) and are left out rather than bolt on a loose match; a video-specific legend could be added separately.

It attaches via a `title` on the existing `.performance` element, so it needs no extra markup. The presentation is easy to change — a styled tooltip, a visible cue, or an inline format — if a different treatment is preferred; the field labels and tuning hint are the substance.
