### PR TITLE
Fix/installer update flow

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1631,7 +1631,7 @@ def check_version(reset=True): # pylint: disable=unused-argument
         if len(latest) != 40:
             log.error(f'Repository error: commit={latest} invalid')
         elif latest != commit and args.upgrade:
-            global quick_allowed # pylint: disable=global-statement
+            global quick_allowed, restart_required # pylint: disable=global-statement
             quick_allowed = False
             log.info('Updating main repository')
             try:
@@ -1640,10 +1640,12 @@ def check_version(reset=True): # pylint: disable=unused-argument
                 update('.', keep_branch=True)
                 # git('git stash pop')
                 ver = git('log -1 --pretty=format:"%h %ad"')
-                log.info(f'Repository upgraded: {ver}')
-                log.warning('Server restart is recommended to apply changes')
-                if ver == latest: # double check
-                    restart()
+                if git('rev-parse HEAD') != commit:
+                    log.info(f'Repository upgraded: {ver}')
+                    log.warning('Server restart is recommended to apply changes')
+                    restart_required = True
+                else:
+                    log.info(f'Repository unchanged: {ver}')
             except Exception:
                 if not reset:
                     log.error('Repository error upgrading')

--- a/installer.py
+++ b/installer.py
@@ -561,7 +561,7 @@ def check_diffusers():
             pip('uninstall --yes diffusers', ignore=True, quiet=True, uv=False)
         if args.skip_git:
             log.warning('Git: marked as not available but required for diffusers installation')
-        pip(f'install --upgrade git+https://github.com/huggingface/diffusers@{target_commit}', ignore=False, quiet=True, uv=False)
+        pip(f'install git+https://github.com/huggingface/diffusers@{target_commit}', ignore=False, quiet=True, uv=False)
         global diffusers_commit # pylint: disable=global-statement
         diffusers_commit = target_commit
     ts('diffusers', t_start)
@@ -592,8 +592,8 @@ def check_transformers():
             else:
                 log.info(f'Update: package="transformers" current={pkg_transformers.version} target={target_transformers}')
             pip('uninstall --yes transformers', ignore=True, quiet=True)
-            pip(f'install --upgrade tokenizers=={target_tokenizers}', ignore=False, quiet=True)
-            pip(f'install --upgrade transformers=={target_transformers}', ignore=False, quiet=True)
+            pip(f'install tokenizers=={target_tokenizers}', ignore=False, quiet=True)
+            pip(f'install transformers=={target_transformers}', ignore=False, quiet=True)
     else:
         # Git commit-pinned version
         current = package_commit(pkg_transformers)
@@ -603,8 +603,8 @@ def check_transformers():
             else:
                 log.info(f'Update: package="transformers" current={pkg_transformers.version} hash={current} target={target_commit}')
             pip('uninstall --yes transformers', ignore=True, quiet=True)
-            pip(f'install --upgrade tokenizers=={target_tokenizers}', ignore=False, quiet=True)
-            pip(f'install --upgrade git+https://github.com/huggingface/transformers@{target_commit}', ignore=False, quiet=True)
+            pip(f'install tokenizers=={target_tokenizers}', ignore=False, quiet=True)
+            pip(f'install git+https://github.com/huggingface/transformers@{target_commit}', ignore=False, quiet=True)
             global transformers_commit # pylint: disable=global-statement
             transformers_commit = target_commit
     ts('transformers', t_start)

--- a/installer.py
+++ b/installer.py
@@ -151,6 +151,14 @@ def package_spec(package):
                 return None
 
 
+def package_commit(spec):
+    try:
+        direct_url = json.loads(spec.read_text('direct_url.json'))
+        return direct_url.get('vcs_info', {}).get('commit_id', '')
+    except Exception:
+        return ''
+
+
 # check if package is installed
 def installed(package, friendly: str | None = None, quiet = False): # pylint: disable=redefined-outer-name
     t_start = time.time()
@@ -544,7 +552,7 @@ def check_diffusers():
     pkg = package_spec('diffusers')
     parts = pkg.version.split('.') if pkg is not None else []
     minor = int(parts[1]) if len(parts) > 1 else -1
-    current = opts.get('diffusers_version', '') if minor > -1 else ''
+    current = package_commit(pkg) if minor > -1 else ''
     if (minor == -1) or ((current != target_commit) and (not args.experimental)):
         if minor == -1:
             log.info(f'Install: package="diffusers" commit={target_commit}')
@@ -588,7 +596,7 @@ def check_transformers():
             pip(f'install --upgrade transformers=={target_transformers}', ignore=False, quiet=True)
     else:
         # Git commit-pinned version
-        current = opts.get('transformers_version', '')
+        current = package_commit(pkg_transformers)
         if args.reinstall or (pkg_transformers is None) or (pkg_transformers.version.startswith('4')) or (current != target_commit):
             if pkg_transformers is None:
                 log.info(f'Install: package="transformers" commit={target_commit}')


### PR DESCRIPTION
## Description

Running with `--update` currently reinstalls transformers twice, once before the automatic restart and once after. The installed-commit marker for git-pinned packages (`transformers_version` / `diffusers_version`) is only persisted at the end of full webui startup, but the post-upgrade restart fires before that point, so the restarted process sees the stale marker and repeats the install. Each reinstall also drags `typing-extensions` past its requirements pin, which the requirements check then reverts, on every launch.

An additional issue this should target is the "missed" update of `Diffusers` that happens intermittently, it's hard for me to 100% reproduce that issue, so I focused on explaining how it fixes what I actually saw and reproduced right now.

Three changes:

- read the installed commit from the package `dist-info` `direct_url.json` instead of the options marker; the options values remain as informational display
- set `restart_required` when the repository update actually moves HEAD; previously the restart depended on a package pin drifting in the same run, since the direct `ver == latest` check compares a short hash and date string against a full sha and never fires; a no-op pull now logs the repository as unchanged and does not restart
- drop `--upgrade` from the pinned tokenizers/transformers/diffusers installs; under `uv` the flag re-resolves the full dependency set eagerly, which is what pulled `typing-extensions` 4.16.0 past the `==4.15.0` pin (4.16.0 released 07-02); the preceding uninstall and exact pins already force the intended change, and dependencies still move when a constraint requires it

These have been tested and the logic makes sense, but you could treat this as "exploratory" PR if you're not completely sure about the changes.

## Notes

- the opts markers are no longer read anywhere; webui.py still writes them so they stay visible in settings
- while testing this, noticed `target_tokenizers` is 0.23.1 but transformers `b70d02fc` requires `tokenizers<=0.23.0`, so every transformers update installs 0.23.1 and immediately resolves it back down (currently to 0.22.2); not touched here since it is a pin value call

## Environment and Testing

Linux (WSL2), python 3.13.13, uv 0.11.15, torch 2.12.0+cu130. Recreated the update scenarios by faking stale commits in dist-info metadata and downgrading `typing-extensions`/`pyparsing`, then launching with `--update`: both packages reinstall once, pins restore once, single restart, and the second pass comes up clean with `launch=quick` and no package activity. A no-op pull (local branch ahead of origin) starts without restarting. The original double install was reproduced on a live update before the change.