### PR TITLE
rocm: detect hipBLASLt lazy library in per-arch subfolder and zlib form

### DIFF
--- a/modules/rocm.py
+++ b/modules/rocm.py
@@ -114,12 +114,16 @@ class Agent:
             self.arch = MicroArchitecture.GCN
         self.is_apu = (self.gfx_version & 0xFFF0 == 0x1150) or self.gfx_version in (0x801, 0x902, 0x90c, 0x1013, 0x1033, 0x1035, 0x1036, 0x1103,)
         blaslt_filename = f"TensileLibrary_lazy_{self.name}.dat"
-        if blaslt_tensile_libpath is not None and os.path.exists(os.path.join(blaslt_tensile_libpath, blaslt_filename)):
-            self.blaslt_supported = True
-        elif blaslt_tensile_libpath is not None and os.path.exists(os.path.join(blaslt_tensile_libpath, self.name, blaslt_filename)):
-            self.blaslt_supported = True
-        else:
+        if blaslt_tensile_libpath is None:
             self.blaslt_supported = False
+        else:
+            search_paths = (
+                os.path.join(blaslt_tensile_libpath, blaslt_filename),
+                os.path.join(blaslt_tensile_libpath, blaslt_filename + ".zlib"),
+                os.path.join(blaslt_tensile_libpath, self.name, blaslt_filename),
+                os.path.join(blaslt_tensile_libpath, self.name, blaslt_filename + ".zlib"),
+            )
+            self.blaslt_supported = any(os.path.exists(p) for p in search_paths)
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
## Description
Fix hipBLASLt being reported as unsupported on recent multi-arch ROCm (TheRock). Newer builds now zlib-compress the lazy Tensile library (e.g. `TensileLibrary_lazy_gfx1100.dat.zlib`), which the existing check misses, so `blaslt_supported` is wrongly `False`.

## Notes
Extends the existing check to also match the `.dat.zlib` variant in both the flat and `<arch>/` locations. All paths use `self.name`, so it stays strict per-arch and still detects the plain `.dat`.

## Environment and Testing
Windows, RDNA4, multi-arch `rocm-sdk`. Confirmed hipBLASLt is now detected and runs instead of falling back to rocBLAS.