### PR TITLE
feat(ui): load unet into secondary slot from networks panel

### DIFF
--- a/modules/ui_extra_networks.py
+++ b/modules/ui_extra_networks.py
@@ -774,7 +774,7 @@ def create_ui(container, button_parent: gr.Button, tabname: str, skip_indexing =
         def ui_tab_change(page):
             scan_visible = page in ['Model', 'Lora', 'VAE', 'UNet/DiT', 'Hypernetwork', 'Embedding']
             save_visible = page in ['Style']
-            model_visible = page in ['Model']
+            model_visible = page in ['Model', 'UNet/DiT']
             return [gr.update(visible=scan_visible), gr.update(visible=save_visible), gr.update(visible=model_visible)]
 
         ui.button_refresh = ui_components.ToolButton(ui_symbols.refresh, elem_id=f"{tabname}_extra_refresh")

--- a/modules/ui_settings.py
+++ b/modules/ui_settings.py
@@ -461,6 +461,13 @@ def create_quicksettings(interfaces):
             inputs=[shared.settings_components["sd_unet"], dummy_component],
             outputs=[shared.settings_components["sd_unet"], text_settings],
         )
+        button_set_unet_secondary = gr.Button("Change UNet secondary", elem_id="change_unet_secondary", visible=False)
+        button_set_unet_secondary.click(
+            fn=lambda value, _: run_settings_single(value, key="sd_unet_secondary"),
+            _js="consumeDesiredUNetName",
+            inputs=[shared.settings_components["sd_unet_secondary"], dummy_component],
+            outputs=[shared.settings_components["sd_unet_secondary"], text_settings],
+        )
 
         def reference_submit(model):
             if '@' not in model: # diffusers

--- a/ui/ui.ts
+++ b/ui/ui.ts
@@ -681,8 +681,12 @@ function getDesiredCheckpointName() {
 
 export function selectUNet(name) {
   desiredUNetName = name;
-  gradioApp().getElementById('change_unet').click();
-  log(`selectUNet: ${desiredUNetName}`);
+  const tabName = getENActiveTab();
+  const btnModel = gradioApp().getElementById(`${tabName}_extra_model`);
+  const isSecondary = btnModel && btnModel.classList.contains('toolbutton-selected');
+  if (isSecondary) gradioApp().getElementById('change_unet_secondary').click();
+  else gradioApp().getElementById('change_unet').click();
+  log(`selectUNet ${isSecondary ? 'secondary' : 'primary'}: ${desiredUNetName}`);
   markSelectedCards([desiredUNetName], 'unet');
 }
 


### PR DESCRIPTION
The refine toggle doubles as the slot selector on the UNet/DiT page: with it active a card click sets sd_unet_secondary instead of sd_unet, mirroring base/refiner selection on the model page.

Kind reminder this will require a dist regen, not pushing to avoid dist churn.