### PR TITLE
fix(rocm): add option to load models without mmap

### DIFF
--- a/modules/sd_models.py
+++ b/modules/sd_models.py
@@ -904,6 +904,7 @@ def load_diffuser(checkpoint_info: CheckpointInfo | None = None, op='model', rev
     timer.load.record("diffusers")
     diffusers_load_config = {
         "low_cpu_mem_usage": True,
+        "disable_mmap": shared.opts.diffusers_disable_mmap,
         "torch_dtype": devices.dtype,
         "load_connected_pipeline": True,
         "safety_checker": None, # sd15 specific but we cant know ahead of time

--- a/modules/ui_definitions.py
+++ b/modules/ui_definitions.py
@@ -93,6 +93,7 @@ def create_settings(cmd_opts):
         "sd_parallel_load": OptionInfo(True, "Model load using multiple threads"),
         "sd_checkpoint_autodownload": OptionInfo(True, "Model auto-download on demand"),
         "stream_load": OptionInfo(False, "Model load using streams", gr.Checkbox),
+        "diffusers_disable_mmap": OptionInfo(False, "Model load without mmap", gr.Checkbox),
         "diffusers_to_gpu": OptionInfo(False, "Model load model direct to GPU"),
         "runai_streamer_diffusers": OptionInfo(False, "Diffusers load using Run:ai streamer", gr.Checkbox),
         "runai_streamer_transformers": OptionInfo(False, "Transformers load using Run:ai streamer", gr.Checkbox),


### PR DESCRIPTION
## Description
Add an option to set "disable_mmap" to true. This fixes ROCm stalling out forever now on large models. I defaulted this to on for "rocm", but it might be a narrower issue than that.

## Notes
On ROCm host-to-device DMA from mmap'd safetensors pages stalls at about 1 second per copy, so weights move to the GPU at ~27 MB/s instead of ~28 GB/s. With offload enabled this re-copies weights every forward, so generation appears to hang.

Added `diffusers_disable_mmap` (Settings > Model Loading), which makes diffusers read shards into anonymous memory instead. Defaults on for ROCm only, since the fix costs peak RAM equal to the model size.

This ROCm issue seems to be related and let me to finding this fix here: https://github.com/ROCm/ROCm/issues/5952

## Environment and Testing
SD3.5-large on RX 9070 (gfx1201), same prompt and steps:
  off: no image after 120s
  on:  image in 20s

| Component | Version |
|-------------------|------------|
| Kernel | 7.0.0-28-generic (24.04.1-Ubuntu SMP PREEMPT_DYNAMIC) |
| amdgpu KMD | in-tree with kernel; no DKMS so driver version is pinned to the kernel |
| ROCm userspace | 7.2.4 (/opt/rocm-7.2.4) |
| HIP runtime | 7.2.26015 (per torch) | 
| rocm-smi-lib | 7.8.0 |
| torch | 2.11.0+rocm7.2 |
| GPU | AMD Radeon RX 9070 — gfx1201 (RDNA4), 16 GB | 
| OS | Ubuntu 24.04.4 LTS |
| safetensors | 0.8.0 |
| diffusers / transformers / accelerate | 0.40.0.dev0 / 5.14.0.dev0 / 1.14.0 |