### PR TITLE
fix(video): count generated frames on the first output axis

### DIFF
--- a/modules/processing_diffusers.py
+++ b/modules/processing_diffusers.py
@@ -204,10 +204,7 @@ def process_base(p: processing.StableDiffusionProcessing):
             t1 = time.time()
             log.debug(f'Profile: pipeline call: {t1-t0:.2f}')
         if not hasattr(output, 'images') and hasattr(output, 'frames'):
-            if hasattr(output.frames[0], 'shape'):
-                log.debug(f'Generated: frames={output.frames[0].shape[1]}')
-            else:
-                log.debug(f'Generated: frames={len(output.frames[0])}')
+            log.debug(f'Generated: frames={len(output.frames[0])}')
             output.images = output.frames[0]
         if hasattr(output, 'images') and isinstance(output.images, np.ndarray):
             output.images = torch.from_numpy(output.images)


### PR DESCRIPTION
Removes a fossil from the logging. The shape branch read axis 1, which held the frame count back when animatediff returned (batch, channels, frames, height, width). Diffusers now returns (batch, frames, channels, height, width) and the modular video path puts channels last, so axis 1 reads channels or height and the line printed a plausible wrong number: a 124 frame 1024x576 generation logged frames=576. len() is the frame count under both layouts and is what the sibling call site in process_decode already uses.