### PR TITLE
fix(framepack): decode tiny video without a second normalize

### DIFF
--- a/modules/framepack/framepack_vae.py
+++ b/modules/framepack/framepack_vae.py
@@ -51,7 +51,7 @@ def vae_decode_tiny(latents):
         taesd = taesd.to(device=devices.device, dtype=devices.dtype)
         latents = latents.transpose(1, 2) # pipe produces NCTHW and tae wants NTCHW
         images = taesd.decode_video(latents, parallel=False, show_progress_bar=False)
-        images = images.transpose(1, 2).mul_(2).sub_(1) # normalize
+        images = images.transpose(1, 2) # taehv decodes to [-1,1] already, which is the range the full vae path returns
         taesd = taesd.to(device=devices.cpu, dtype=devices.dtype)
     return images
 


### PR DESCRIPTION
## Description

FramePack's tiny VAE decode normalized twice. `TAEHV.decode_video` already returns `[-1,1]`, and `framepack_vae.vae_decode_tiny` applied its own `x2-1` on top, landing near `[-3,1]` where `framepack_worker` documents its pixels as `[-1,1]`. Values below zero clip to black, so the result was a much darker video rather than an error.

Ladies and gentlemen, difference between QA and unit testing.

## Notes

The path was unreachable until #5038 made the taesd loader honor an explicitly requested variant. Before that, `load_model(variant='TAE HunyuanVideo')` returned `None` and the decode raised `AttributeError`, so `FP VAE = Tiny` was a hard failure and the range was never observed. It is called once per section inside the sampling loop.

## Environment and Testing

Measured and eyeballed. To quantify, mean luma over 12 frames FramePack I2V bi-directional at 384: Tiny before 25.3, full VAE reference 92.1, Tiny after 92.6. 0.6%.