### PR TITLE
fix(queue): stop the queue lock from suppressing exceptions

### DIFF
--- a/modules/call_queue.py
+++ b/modules/call_queue.py
@@ -25,7 +25,7 @@ class Queue:
         if _queue_debug:
             fn = f'{sys._getframe(3).f_code.co_name}:{sys._getframe(2).f_code.co_name}:{sys._getframe(1).f_code.co_name}' # pylint: disable=protected-access
             log.debug(f'Queue: unlock state={_queue_lock.locked()} fn={fn}')
-        return _queue_lock
+        # no return: a truthy __exit__ suppresses the exception in flight
 
 
 queue_lock = Queue() # public lock for external use

--- a/modules/video_models/video_run.py
+++ b/modules/video_models/video_run.py
@@ -307,6 +307,10 @@ def run(selected: models_def.Model, *,
     if err:
         raise VideoError(err, 500)
     if processed is None or (len(processed.images) == 0 and processed.bytes is None):
+        # process_images swallows the interrupt assertion, so an empty result is the only place
+        # a cancel and a genuine failure are still distinguishable
+        if shared.state.interrupted or shared.state.skipped:
+            raise VideoError('interrupted', 499)
         raise VideoError('processing failed', 500)
     log.info(f'Video: name="{selected.name}" cls={shared.sd_model.__class__.__name__} frames={len(processed.images)} time={t1-t0:.2f}')
 


### PR DESCRIPTION
## Description

`Queue.__exit__` returned `_queue_lock`, and a truthy `__exit__` return suppresses the exception in flight, so every `with queue_lock:` block discarded exceptions and resumed with locals from the aborted block unassigned. Regression from 63a572242; the bare `threading.Lock` it replaced returned `None`.

```
02:27:29-524245 DEBUG    State: interrupt requested
02:27:29-534684 DEBUG    State: interrupt requested
02:27:29-536781 INFO     API user=None code=200 http/1.1 DELETE /sdapi/v2/jobs/848a0df0a5a84622 127.0.0.1 0.0077
Progress 21.93s/it ██▌              17% 5/29 01:49 08:46
02:27:44-075257 ERROR    Error in block: (MiniMaxH3Blocks):

02:27:44-075257 ERROR    Error in block: (MiniMaxH3Blocks):

02:27:44-075257 ERROR    Error in block: (MiniMaxH3Blocks):

02:27:44-080940 INFO     Interrupted...
02:27:44-083558 INFO     Processing modifiers: unapply
02:27:44-087631 DEBUG    Process: batch=1/1 interrupted
02:27:44-089122 INFO     Processed: images=0 its=0.000 ops=['video', 'modular']
02:27:44-090196 DEBUG    Processed: timers={'process': 167.77, 'wall': 167.77, 'post': 167.71, 'onload': 4.78, 'offload': 4.08}
02:27:44-091881 DEBUG    Processed: memory={'ram': {'total': 94.29, 'rss': 48.49, 'used': 48.77, 'free': 38.44, 'avail': 45.52, 'buffers': 0.05, 'cached': 26.43}, 'gpu': {'used': 10.42, 'total': 24.0, 'active': 1.84, 'peak': 14.27, 'retries': 0, 'oom': 0, 'swap': 0}, 'job': ''}
02:27:44-094944 DEBUG    Processed: autotune={'_shapes': 23, 'sdnq_scaled_mm_kernel': 0.2399, 'sdnq_attn_kernel': 0.0563}
02:27:44-102591 DEBUG    Processed: dynamo={'_compile.compile_inner': 16.74, 'compile_attempt_0': 14.19, 'bytecode_tracing': 7.36, 'OutputGraph.call_user_compiler': 5.79, 'get_fake_value': 2.18, 'build_guards': 2.12, 'variable_builder_call': 1.87, 'CacheBase.get_system.triton_key':
                         1.65, 'create_proxy': 1.46, 'AOTAutogradCache.inductor_load': 1.44}
02:27:44-107602 ERROR    Job queue: video: UnboundLocalError
/home/ohiom/sdnext_dev/extensions/enso/enso_api/job_queue.py:358 in _run_local_job

  357                 result = executor_fn(params, job_id)
❱ 358             self.output_register_failures += assign_output_urls(self.store, result, job_id)
  359             result_json = json.dumps(result, default=str)
UnboundLocalError: cannot access local variable 'result' where it is not associated with a value
```