### PR TITLE
fix(todo): drop the unreachable duplicate cuda branch in init_generator

### DIFF
--- a/modules/todo/todo_merge.py
+++ b/modules/todo/todo_merge.py
@@ -29,8 +29,6 @@ def init_generator(device: torch.device, fallback: torch.Generator = None):
         return torch.Generator(device="cpu").set_state(torch.get_rng_state())
     elif device.type == "cuda":
         return torch.Generator(device=device).set_state(torch.cuda.get_rng_state())
-    elif device.type == "cuda":
-        return torch.Generator(device=device).set_state(torch.mps.get_rng_state())
     else:
         if fallback is None:
             return init_generator(torch.device("cpu"))


### PR DESCRIPTION
`modules/todo/todo_merge.py::init_generator` tests the same device type twice:

```python
    if device.type == "cpu":
        return torch.Generator(device="cpu").set_state(torch.get_rng_state())
    elif device.type == "cuda":
        return torch.Generator(device=device).set_state(torch.cuda.get_rng_state())
    elif device.type == "cuda":                                  # <- never reached
        return torch.Generator(device=device).set_state(torch.mps.get_rng_state())
    else:
        ...
```

The third branch is unreachable — the second `elif` already claims every CUDA device. From the body (`torch.mps.get_rng_state()`) the intent was clearly `device.type == "mps"`.

The reason to delete it rather than repair the condition is that repairing it would break MPS:

```
>>> torch.Generator(device="mps")
RuntimeError: Device type MPS is not supported for torch.Generator() api.
```

(torch 2.5.1; the check is a device-type gate in the Generator constructor, not an availability check, so it fires on macOS builds too — only `cpu` and `cuda` are accepted.) So the branch is a trap: it looks like a one-character typo, and "fixing" it would turn a working MPS path into a hard crash.

Nothing changes for anybody today. MPS already falls through to the `else` branch, which recurses into `init_generator(torch.device("cpu"))` — or returns the caller's `fallback` — and `bipartite_soft_matching_random2d` then draws `rand_idx` with `device=generator.device` and moves it with `.to(metric.device)`, so a CPU generator is fine there.

This also brings the helper back in line with the repo's other copy of it, `modules/hidiffusion/utils.py:19`, which has exactly `cpu` / `cuda` / `else` and no third branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
