### PR TITLE
fix: honor offline mode in model loaders

### DIFF
--- a/modules/ltx/ltx_util.py
+++ b/modules/ltx/ltx_util.py
@@ -59,11 +59,13 @@ def load_upsample(upsample_pipe, upsample_repo_id):
         t0 = time.time()
         from diffusers.pipelines.ltx.pipeline_ltx_latent_upsample import LTXLatentUpsamplePipeline
         log.info(f'Load video: cls={LTXLatentUpsamplePipeline.__name__} repo="{upsample_repo_id}"')
+        offline_args = {'local_files_only': True} if shared.opts.offline_mode else {}
         upsample_pipe = LTXLatentUpsamplePipeline.from_pretrained(
             upsample_repo_id,
             vae=shared.sd_model.vae,
             cache_dir=shared.opts.hfcache_dir,
             torch_dtype=devices.dtype,
+            **offline_args,
         )
         # only the upsampler, since the pipe borrows the model's vae and moving the whole pipe
         # would drag that along into the meta tensors the caller's offload exclude avoids
@@ -85,11 +87,13 @@ def load_upsample_2x(upsample_pipe, upsample_repo_id, variant: str = '2.x'):
         from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
         from modules import sd_checkpoint
         log.info(f'Load video: cls={LTX2LatentUpsamplePipeline.__name__} repo="{upsample_repo_id}"')
+        offline_args = {'local_files_only': True} if shared.opts.offline_mode else {}
         latent_upsampler = LTX2LatentUpsamplerModel.from_pretrained(
             upsample_repo_id,
             subfolder='latent_upsampler',
             cache_dir=shared.opts.hfcache_dir,
             torch_dtype=devices.dtype,
+            **offline_args,
         ).to(devices.device)
         upsample_pipe = LTX2LatentUpsamplePipeline(
             vae=shared.sd_model.vae,

--- a/modules/model_te.py
+++ b/modules/model_te.py
@@ -17,6 +17,7 @@ def load_t5(name=None, cache_dir=None):
     if name is None:
         return None
     cache_dir = cache_dir or shared.opts.hfcache_dir
+    offline_args = {'local_files_only': True} if shared.opts.offline_mode else {}
     from modules import modelloader
     modelloader.hf_login()
     repo_id = 'stabilityai/stable-diffusion-3-medium-diffusers'
@@ -60,25 +61,25 @@ def load_t5(name=None, cache_dir=None):
         t5 = transformers.T5EncoderModel.from_pretrained(None, state_dict=state_dict, config=t5_config, cache_dir=cache_dir, torch_dtype=devices.dtype)
 
     elif 'fp16' in name.lower():
-        t5 = transformers.T5EncoderModel.from_pretrained(repo_id, subfolder='text_encoder_3', cache_dir=cache_dir, torch_dtype=devices.dtype)
+        t5 = transformers.T5EncoderModel.from_pretrained(repo_id, subfolder='text_encoder_3', cache_dir=cache_dir, torch_dtype=devices.dtype, **offline_args)
 
     elif 'int8' in name.lower():
         from modules.model_quant import create_sdnq_config
         quantization_config = create_sdnq_config(kwargs=None, allow=True, module='any', weights_dtype='int8')
         if quantization_config is not None:
-            t5 = transformers.T5EncoderModel.from_pretrained(repo_id, subfolder='text_encoder_3', quantization_config=quantization_config, cache_dir=cache_dir, torch_dtype=devices.dtype)
+            t5 = transformers.T5EncoderModel.from_pretrained(repo_id, subfolder='text_encoder_3', quantization_config=quantization_config, cache_dir=cache_dir, torch_dtype=devices.dtype, **offline_args)
 
     elif 'uint4' in name.lower():
         from modules.model_quant import create_sdnq_config
         quantization_config = create_sdnq_config(kwargs=None, allow=True, module='any', weights_dtype='uint4')
         if quantization_config is not None:
-            t5 = transformers.T5EncoderModel.from_pretrained(repo_id, subfolder='text_encoder_3', quantization_config=quantization_config, cache_dir=cache_dir, torch_dtype=devices.dtype)
+            t5 = transformers.T5EncoderModel.from_pretrained(repo_id, subfolder='text_encoder_3', quantization_config=quantization_config, cache_dir=cache_dir, torch_dtype=devices.dtype, **offline_args)
 
     elif '/' in name:
         log.debug(f'Load model: type=T5 repo={name}')
         quant_config = model_quant.create_config(module='TE')
         if quant_config is not None:
-            t5 = transformers.T5EncoderModel.from_pretrained(name, cache_dir=cache_dir, torch_dtype=devices.dtype, **quant_config)
+            t5 = transformers.T5EncoderModel.from_pretrained(name, cache_dir=cache_dir, torch_dtype=devices.dtype, **quant_config, **offline_args)
 
     else:
         t5 = None

--- a/modules/video_models/video_load.py
+++ b/modules/video_models/video_load.py
@@ -221,7 +221,8 @@ def load_upscale_vae():
 
     repo_id = 'spacepxl/Wan2.1-VAE-upscale2x'
     subfolder = "diffusers/Wan2.1_VAE_upscale2x_imageonly_real_v1"
-    vae_decode = diffusers.AutoencoderKLWan.from_pretrained(repo_id, subfolder=subfolder, cache_dir=shared.opts.hfcache_dir)
+    offline_args = {'local_files_only': True} if shared.opts.offline_mode else {}
+    vae_decode = diffusers.AutoencoderKLWan.from_pretrained(repo_id, subfolder=subfolder, cache_dir=shared.opts.hfcache_dir, **offline_args)
     vae_decode.requires_grad_(False)
     vae_decode = vae_decode.to(device=devices.device, dtype=devices.dtype)
     vae_decode.eval()

--- a/pipelines/generic_text_encoder.py
+++ b/pipelines/generic_text_encoder.py
@@ -64,6 +64,8 @@ def load_local_file(local_file, cls_name, quant_type, repo_id=None, dtype=None, 
         cfg_args = {'cache_dir': shared.opts.hfcache_dir}
         if extra.get('subfolder') is not None:
             cfg_args['subfolder'] = extra['subfolder']
+        if shared.opts.offline_mode:
+            cfg_args['local_files_only'] = True
         log.debug(f'Load model: text_encoder="{local_file}" cls={cls_name.__name__} config="{config_repo}" quant="{quant_type}" loader={get_loader("transformers")} file=safetensors')
         config = transformers.AutoConfig.from_pretrained(config_repo, **cfg_args)
         state_dict = load_file(local_file)
@@ -120,6 +122,8 @@ def load_text_encoder(
             load_args['use_safetensors'] = True
         if trust_remote_code:
             load_args['trust_remote_code'] = True
+        if shared.opts.offline_mode:
+            load_args['local_files_only'] = True
 
         # 1. load override from local file
         local_file = None

--- a/pipelines/generic_transformer.py
+++ b/pipelines/generic_transformer.py
@@ -48,6 +48,7 @@ def load_transformer(
         modules_to_not_convert = []
     if modules_dtype_dict is None:
         modules_dtype_dict = {}
+    offline_args = {'local_files_only': True} if shared.opts.offline_mode else {}
     jobid = shared.state.begin('Load DiT')
     try:
         load_args, quant_args = model_quant.get_dit_args(load_config, module='Model', device_map=True, allow_quant=allow_quant, modules_to_not_convert=modules_to_not_convert, modules_dtype_dict=modules_dtype_dict)
@@ -73,12 +74,11 @@ def load_transformer(
                 load_args['use_safetensors'] = True
             if trust_remote_code:
                 load_args['trust_remote_code'] = True
+            load_kwargs = {**load_args, **quant_args, **offline_args, **kwargs}
             return cls_name.from_pretrained(
                 repo_id,
                 cache_dir=shared.opts.hfcache_dir,
-                **load_args,
-                **quant_args,
-                **kwargs,
+                **load_kwargs,
             )
 
         local_file = None
@@ -151,12 +151,11 @@ def load_transformer(
             load_args.pop('device_map', None) # single-file uses different syntax
             loader = cls_name.from_single_file if hasattr(cls_name, 'from_single_file') else cls_name.from_pretrained
             log.debug(f'Load model: transformer="{local_file}" cls={cls_name.__name__} quant="{quant_type}" loader={get_loader("diffusers")} method={loader.__name__} args={load_args}')
+            load_kwargs = {**load_args, **quant_args, **offline_args, **kwargs}
             transformer = loader(
                 local_file,
                 cache_dir=shared.opts.hfcache_dir,
-                **load_args,
-                **quant_args,
-                **kwargs,
+                **load_kwargs,
             )
 
         # 4. default loading from diffusers repo (also the fallback when an

--- a/pipelines/native_transformer.py
+++ b/pipelines/native_transformer.py
@@ -697,8 +697,9 @@ def partition_siblings(
 def fetch_component_config(repo_id: str, subfolder: str) -> dict:
     """Download and parse ``<subfolder>/config.json`` from the base repo."""
     relative_path = f"{subfolder}/config.json"
+    offline_args = {'local_files_only': True} if shared.opts.offline_mode else {}
     try:
-        local = hf.hf_hub_download(repo_id, filename=relative_path, cache_dir=shared.opts.diffusers_dir)
+        local = hf.hf_hub_download(repo_id, filename=relative_path, cache_dir=shared.opts.diffusers_dir, **offline_args)
     except Exception as e:
         log.error(f' path="{relative_path}" repo="{repo_id}" failed to download: {e}')
         raise RuntimeError('') from e


### PR DESCRIPTION
Several model-loading paths never pass `local_files_only=True` to `from_pretrained` / `hf_hub_download`, so they still hit the HuggingFace Hub at load time even when `offline_mode` is enabled.

Pass `local_files_only=True` when offline mode is enabled for LTX upsamplers, T5 encoders, Wan upscale VAE loading, generic text encoders and transformers, and native component config downloads.

Tests:
- `./webui.sh --test`
- Targeted Ruff and Pylint checks
- Test generations with Flux2 and LTX 2.5